### PR TITLE
feat: MCP + vector DB lab foundations

### DIFF
--- a/curriculum/presentable/02_intermediate/chapter_03_context_engineering.md
+++ b/curriculum/presentable/02_intermediate/chapter_03_context_engineering.md
@@ -778,6 +778,42 @@ The key is determinism: the agent should make the same decision every time given
 
 ---
 
+### 3.5.1 Context Packing Policy + Evidence Manifest
+
+In production, you want a *repeatable* answer to: "What did we put into the prompt, and why?"
+
+Start with a deterministic packing order (example):
+
+1. System instructions
+2. Current user request (goal + constraints)
+3. Tool contracts (names + schemas for tools available this run)
+4. Retrieved evidence (RAG results), **with provenance**
+5. Long-term memory (facts), **with confidence + provenance**
+6. Conversation history (recent turns)
+7. Summaries (only if needed to fit budget)
+
+Then produce a lightweight **evidence manifest** alongside the prompt. This is not sent to the user by default, but it is logged for debugging and evaluation.
+
+Example manifest shape:
+
+```json
+{
+  "request_id": "req-123",
+  "budget": {"max_tokens": 8000, "reserved_response_tokens": 1000},
+  "items": [
+    {"kind": "tool_schema", "name": "ticket_read", "tokens": 120, "reason": "tool available"},
+    {"kind": "evidence", "doc_id": "runbook-7", "chunk_id": "c12", "tokens": 260, "reason": "retrieval_top_k"},
+    {"kind": "memory_fact", "key": "user_pref", "tokens": 40, "reason": "high_confidence"}
+  ]
+}
+```
+
+This makes it easier to:
+
+- debug wrong answers ("what evidence did we include?")
+- evaluate changes ("did new chunking change evidence coverage?")
+- audit sensitive decisions ("did we include the right documents for this tenant?")
+
 ## Implementation Guide (using core modules)
 
 Use these repo assets to make the chapter actionable:

--- a/curriculum/presentable/03_advanced/chapter_06_security_best_practices.md
+++ b/curriculum/presentable/03_advanced/chapter_06_security_best_practices.md
@@ -235,6 +235,39 @@ Common isolation failures:
 
 A useful mental model: tenant_id is a required parameter of every privileged operation. If a function does not accept tenant_id, it is suspicious.
 
+### E) Remote tool servers (MCP)
+
+If you adopt remote tool servers (e.g., via MCP), treat them as a first-class security boundary:
+
+- The model is not trusted; tool calls must be validated and authorized in code.
+- The tool server is a dependency; it can fail, be misconfigured, or be compromised.
+
+Minimum controls for MCP-style tool execution:
+
+1. **Allowlist tools per workflow** (deny by default)
+2. **Validate inputs** against tool schemas before sending to the server
+3. **Bind identity to every call**:
+   - `tenant_id` (required)
+   - `actor_id` / roles
+   - `request_id` / `tool_call_id` (for traceability)
+4. **Audit events** for every tool call (especially writes):
+   - tool name, action, outcome, latency, and sanitized metadata
+5. **Do not trust tool output** as safe instructions:
+   - tool output can contain injection strings; treat it like any other untrusted input channel
+
+Example audit event fields (metadata only):
+
+```json
+{
+  "event": "remote_tool_call_completed",
+  "request_id": "req-123",
+  "tenant_id": "t-9",
+  "tool": "repo_read_file",
+  "status": "success",
+  "latency_ms": 42
+}
+```
+
 ---
 
 ## 3) Authentication and Authorization Patterns

--- a/labs/09/README.md
+++ b/labs/09/README.md
@@ -1,0 +1,29 @@
+# Lab 9: MCP Tool Servers (Offline Foundations)
+
+## Overview
+This lab introduces **Model Context Protocol (MCP)** concepts using an offline, deterministic "fake MCP server".
+
+Goals:
+- Discover tools from an MCP-like server
+- Allowlist which tools are exposed to the agent
+- Invoke remote tools through the existing `agent_labs.tools.ToolRegistry`
+- Capture basic correlation metadata (`request_id`, `tool_call_id`)
+
+## Quick Start
+
+```powershell
+# From repo root
+$env:PYTHONPATH='.'; python labs/09/src/mcp_client_agent.py
+$env:PYTHONPATH='.'; pytest labs/09/tests/test_mcp_lab.py -v --capture=tee-sys
+```
+
+## Exercises
+- `exercises/exercise_1.md` - Tool discovery
+- `exercises/exercise_2.md` - Allowlist + schema validation
+- `exercises/exercise_3.md` - Correlation IDs + observability fields
+
+## Files
+- `src/mcp_client_agent.py` - Example agent that discovers + calls MCP tools
+- `src/fake_mcp.py` - Deterministic fake MCP client/server
+- `tests/test_mcp_lab.py` - Offline tests
+

--- a/labs/09/exercises/exercise_1.md
+++ b/labs/09/exercises/exercise_1.md
@@ -1,0 +1,6 @@
+# Exercise 1: Tool discovery
+
+1) Run `labs/09/src/mcp_client_agent.py` and confirm it prints the discovered tool call result.
+
+2) Modify `build_registry_from_mcp()` to print the discovered tool names before allowlisting.
+

--- a/labs/09/exercises/exercise_2.md
+++ b/labs/09/exercises/exercise_2.md
@@ -1,0 +1,8 @@
+# Exercise 2: Allowlist + schema validation
+
+1) Set `allowlist={"echo"}` and verify `add` cannot be executed.
+
+2) Trigger schema validation failure:
+- Call `add` with missing `b`
+- Observe the returned status is `invalid_input` and includes a clear error message.
+

--- a/labs/09/exercises/exercise_3.md
+++ b/labs/09/exercises/exercise_3.md
@@ -1,0 +1,8 @@
+# Exercise 3: Correlation IDs
+
+1) Pass `__request_id` and `__tool_call_id` to `registry.execute(...)`.
+
+2) Confirm the returned `ToolResult.metadata` contains those fields.
+
+3) Add one more field (e.g., `__tenant_id`) and confirm it is carried through.
+

--- a/labs/09/src/fake_mcp.py
+++ b/labs/09/src/fake_mcp.py
@@ -1,0 +1,83 @@
+"""Fake MCP server/client for offline labs.
+
+This intentionally does not implement the full MCP spec. It provides the same
+two primitives needed for teaching:
+- list_tools()
+- call_tool(name, arguments)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from src.agent_labs.mcp import (
+    McpInvalidArgumentsError,
+    McpTool,
+    McpToolCallResult,
+    McpToolNotFoundError,
+)
+
+
+@dataclass
+class FakeMcpConfig:
+    timeout_s: Optional[float] = None
+
+
+class FakeMcpClient:
+    def __init__(self, config: Optional[FakeMcpConfig] = None) -> None:
+        self.config = config or FakeMcpConfig()
+        self.calls: list[dict] = []
+        self._tools = [
+            McpTool(
+                name="echo",
+                description="Echo back input text.",
+                input_schema={
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+                output_schema={"type": "string"},
+            ),
+            McpTool(
+                name="add",
+                description="Add two numbers.",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "number"},
+                        "b": {"type": "number"},
+                    },
+                    "required": ["a", "b"],
+                },
+                output_schema={"type": "number"},
+            ),
+        ]
+
+    def list_tools(self) -> List[McpTool]:
+        return list(self._tools)
+
+    def call_tool(
+        self,
+        name: str,
+        arguments: Dict[str, object],
+        *,
+        timeout_s: Optional[float] = None,
+    ) -> McpToolCallResult:
+        self.calls.append({"name": name, "arguments": dict(arguments), "timeout_s": timeout_s})
+
+        if name == "echo":
+            if "text" not in arguments:
+                raise McpInvalidArgumentsError("Missing required field: text")
+            return McpToolCallResult(content=str(arguments["text"]), metadata={"server": "fake"})
+
+        if name == "add":
+            if "a" not in arguments or "b" not in arguments:
+                raise McpInvalidArgumentsError("Missing required fields: a, b")
+            return McpToolCallResult(
+                content=float(arguments["a"]) + float(arguments["b"]),
+                metadata={"server": "fake"},
+            )
+
+        raise McpToolNotFoundError(f"Tool not found: {name}")
+

--- a/labs/09/src/mcp_client_agent.py
+++ b/labs/09/src/mcp_client_agent.py
@@ -1,0 +1,34 @@
+"""Lab 09 demo: discover and invoke MCP tools through ToolRegistry."""
+
+from __future__ import annotations
+
+import asyncio
+
+from src.agent_labs.mcp import McpToolAdapter
+from src.agent_labs.tools import ToolRegistry
+
+from fake_mcp import FakeMcpClient
+
+
+def build_registry_from_mcp(*, allowlist: set[str]) -> ToolRegistry:
+    client = FakeMcpClient()
+    registry = ToolRegistry()
+
+    for tool in client.list_tools():
+        if tool.name not in allowlist:
+            continue
+        registry.register(McpToolAdapter(client, tool))
+
+    return registry
+
+
+async def main() -> None:
+    registry = build_registry_from_mcp(allowlist={"echo", "add"})
+
+    # Correlation metadata can be passed via reserved kwargs (prefixed with "__").
+    result = await registry.execute("add", a=2, b=3, __request_id="req-1", __tool_call_id="tc-1")
+    print(result.to_dict())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/labs/09/tests/test_mcp_lab.py
+++ b/labs/09/tests/test_mcp_lab.py
@@ -1,0 +1,26 @@
+import pytest
+import sys
+from pathlib import Path
+
+from src.agent_labs.tools import ExecutionStatus
+
+# Add lab src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from mcp_client_agent import build_registry_from_mcp
+
+
+@pytest.mark.asyncio
+async def test_lab_09_registry_executes_allowlisted_tools():
+    registry = build_registry_from_mcp(allowlist={"add"})
+    result = await registry.execute("add", a=1, b=2, __request_id="req-9")
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.output == 3.0
+    assert result.metadata["request_id"] == "req-9"
+
+
+@pytest.mark.asyncio
+async def test_lab_09_allowlist_blocks_tools():
+    registry = build_registry_from_mcp(allowlist=set())
+    result = await registry.execute("add", a=1, b=2)
+    assert result.status == ExecutionStatus.NOT_FOUND

--- a/labs/10/README.md
+++ b/labs/10/README.md
@@ -1,0 +1,30 @@
+# Lab 10: Vector DB + Context Packing + Memory Management (Offline, Deterministic)
+
+## Overview
+This lab focuses on **vector retrieval patterns** plus **context packing** and **memory consolidation**.
+
+It is intentionally offline-first:
+- Uses `src.agent_labs.retrieval.InMemoryVectorIndex` (deterministic embeddings)
+- Produces provenance fields (`doc_id`, `chunk_id`, `source`, `timestamp`, metadata)
+- Produces a context manifest ("what was included and why")
+- Demonstrates a small golden-set evaluation run
+
+## Quick Start
+
+```powershell
+# From repo root
+$env:PYTHONPATH='.'; python labs/10/src/run_demo.py
+$env:PYTHONPATH='.'; pytest labs/10/tests/test_vector_lab.py -v --capture=tee-sys
+```
+
+## Exercises
+- `exercises/exercise_1.md` - Ingest + metadata filters
+- `exercises/exercise_2.md` - Context packing manifest
+- `exercises/exercise_3.md` - Memory consolidation + golden set evaluation
+
+## Notes (Production Path)
+This lab uses an in-memory vector index for determinism. In production, the same interfaces can be backed by:
+- Postgres + pgvector
+- Chroma persistent
+- Managed vector DB (Pinecone/Qdrant/Weaviate)
+

--- a/labs/10/exercises/exercise_1.md
+++ b/labs/10/exercises/exercise_1.md
@@ -1,0 +1,6 @@
+# Exercise 1: Ingest + metadata filters
+
+1) Run `labs/10/src/run_demo.py`.
+
+2) Add a new document for `tenant_id="t1"` and confirm it does not appear when you query with `tenant_id="t2"`.
+

--- a/labs/10/exercises/exercise_2.md
+++ b/labs/10/exercises/exercise_2.md
@@ -1,0 +1,8 @@
+# Exercise 2: Context packing manifest
+
+1) In `vector_agent.py`, add a manifest item for the user question itself:
+- kind: `user_request`
+- reason: `primary_input`
+
+2) Verify the manifest includes both `user_request` and `evidence` items.
+

--- a/labs/10/exercises/exercise_3.md
+++ b/labs/10/exercises/exercise_3.md
@@ -1,0 +1,10 @@
+# Exercise 3: Memory consolidation + evaluation
+
+1) Inspect `VectorRagAgent.semantic_facts` after multiple calls.
+
+2) Extend `_consolidate_memory` to store:
+- number of episodes per tenant
+- last cited doc_id
+
+3) Run the golden set evaluation (`evaluate.py`) and confirm results remain deterministic.
+

--- a/labs/10/src/dataset.py
+++ b/labs/10/src/dataset.py
@@ -1,0 +1,63 @@
+"""Small deterministic dataset for Lab 10."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True)
+class Doc:
+    doc_id: str
+    source: str
+    tenant_id: str
+    text: str
+
+
+@dataclass(frozen=True)
+class GoldenCase:
+    case_id: str
+    tenant_id: str
+    question: str
+    reference_answer: str
+
+
+def sample_docs() -> List[Doc]:
+    return [
+        Doc(
+            doc_id="runbook-1",
+            source="runbook",
+            tenant_id="t1",
+            text="Reset password steps. Step 1: verify identity. Step 2: rotate token.",
+        ),
+        Doc(
+            doc_id="kb-1",
+            source="kb",
+            tenant_id="t1",
+            text="MCP is a tool server protocol. It supports tool discovery and invocation.",
+        ),
+        Doc(
+            doc_id="kb-2",
+            source="kb",
+            tenant_id="t2",
+            text="Tenant t2 only: refund policy. Refunds require approval.",
+        ),
+    ]
+
+
+def golden_set() -> List[GoldenCase]:
+    return [
+        GoldenCase(
+            case_id="c1",
+            tenant_id="t1",
+            question="What is MCP?",
+            reference_answer="MCP is a tool server protocol.",
+        ),
+        GoldenCase(
+            case_id="c2",
+            tenant_id="t1",
+            question="How do I reset password?",
+            reference_answer="Reset password steps.",
+        ),
+    ]
+

--- a/labs/10/src/evaluate.py
+++ b/labs/10/src/evaluate.py
@@ -1,0 +1,29 @@
+"""Golden-set style evaluation (offline)."""
+
+from __future__ import annotations
+
+from typing import List
+
+from src.agent_labs.evaluation import BenchmarkCase, BenchmarkRunner, ExactMatchScorer
+
+from dataset import GoldenCase
+from vector_agent import VectorRagAgent
+
+
+def run_golden_set(agent: VectorRagAgent, cases: List[GoldenCase]) -> float:
+    scorer = ExactMatchScorer()
+    runner = BenchmarkRunner(metric=scorer)
+
+    benchmark_cases = [
+        BenchmarkCase(case_id=c.case_id, input_text=c.question, reference=c.reference_answer)
+        for c in cases
+    ]
+    outputs = {}
+    for c in cases:
+        out = agent.answer(c.question, tenant_id=c.tenant_id, request_id=f"req-{c.case_id}")
+        outputs[c.case_id] = out["answer"]
+
+    result = runner.run(benchmark_cases, outputs)
+    scores = [float(row["score"]) for row in result.cases]
+    return sum(scores) / max(1, len(scores))
+

--- a/labs/10/src/ingest.py
+++ b/labs/10/src/ingest.py
@@ -1,0 +1,31 @@
+"""Ingestion pipeline: chunk -> record -> upsert."""
+
+from __future__ import annotations
+
+from typing import List
+
+from src.agent_labs.context import chunk_semantic_mock
+from src.agent_labs.retrieval import ChunkRecord, VectorIndex
+
+from dataset import Doc
+
+
+def ingest_docs(index: VectorIndex, docs: List[Doc]) -> int:
+    records: list[ChunkRecord] = []
+    for doc in docs:
+        chunks = chunk_semantic_mock(doc.text, max_chars=200)
+        for i, chunk in enumerate(chunks):
+            records.append(
+                ChunkRecord(
+                    doc_id=doc.doc_id,
+                    chunk_id=f"c{i+1}",
+                    text=chunk,
+                    metadata={
+                        "tenant_id": doc.tenant_id,
+                        "source": doc.source,
+                    },
+                )
+            )
+    index.upsert(records)
+    return len(records)
+

--- a/labs/10/src/run_demo.py
+++ b/labs/10/src/run_demo.py
@@ -1,0 +1,30 @@
+"""Run the Lab 10 demo end-to-end."""
+
+from __future__ import annotations
+
+from src.agent_labs.retrieval import InMemoryVectorIndex
+
+from dataset import golden_set, sample_docs
+from ingest import ingest_docs
+from vector_agent import VectorRagAgent
+from evaluate import run_golden_set
+
+
+def main() -> None:
+    index = InMemoryVectorIndex()
+    count = ingest_docs(index, sample_docs())
+    print(f"Ingested chunks: {count}")
+
+    agent = VectorRagAgent(index=index)
+    response = agent.answer("What is MCP?", tenant_id="t1", request_id="req-demo")
+    print(response["answer"])
+    print(response["citations"])
+    print(response["manifest"])
+
+    avg = run_golden_set(agent, golden_set())
+    print(f"Golden set average score: {avg}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/labs/10/src/vector_agent.py
+++ b/labs/10/src/vector_agent.py
@@ -1,0 +1,117 @@
+"""Vector retrieval + context packing + memory consolidation (educational)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from src.agent_labs.context import ContextManifest, TokenCounter
+from src.agent_labs.retrieval import RetrievedChunk, VectorIndex
+
+
+@dataclass
+class Episode:
+    tenant_id: str
+    question: str
+    answer: str
+    citations: list[dict]
+
+
+@dataclass
+class SemanticFact:
+    key: str
+    value: str
+    tenant_id: str
+
+
+@dataclass
+class VectorRagAgent:
+    index: VectorIndex
+    max_tokens: int = 2000
+    reserved_response_tokens: int = 200
+    episodes: List[Episode] = field(default_factory=list)
+    semantic_facts: Dict[str, SemanticFact] = field(default_factory=dict)
+
+    def answer(
+        self,
+        question: str,
+        *,
+        tenant_id: str,
+        request_id: str,
+        top_k: int = 2,
+    ) -> dict:
+        retrieved = self.index.query(
+            question,
+            top_k=top_k,
+            filters={"tenant_id": tenant_id},
+        )
+
+        manifest = ContextManifest(
+            request_id=request_id,
+            max_tokens=self.max_tokens,
+            reserved_response_tokens=self.reserved_response_tokens,
+        )
+
+        citations: list[dict] = []
+        for chunk in retrieved:
+            citations.append(
+                {
+                    "doc_id": chunk.doc_id,
+                    "chunk_id": chunk.chunk_id,
+                    "source": chunk.metadata.get("source"),
+                }
+            )
+            manifest.add_item(
+                kind="evidence",
+                tokens=TokenCounter.count(chunk.text),
+                reason="retrieval_top_k",
+                metadata={
+                    "doc_id": chunk.doc_id,
+                    "chunk_id": chunk.chunk_id,
+                    "source": chunk.metadata.get("source"),
+                },
+            )
+
+        answer_text = self._generate_deterministic_answer(question, retrieved)
+
+        self.episodes.append(
+            Episode(
+                tenant_id=tenant_id,
+                question=question,
+                answer=answer_text,
+                citations=citations,
+            )
+        )
+        self._consolidate_memory(tenant_id=tenant_id)
+
+        return {
+            "answer": answer_text,
+            "citations": citations,
+            "manifest": manifest.to_dict(),
+        }
+
+    @staticmethod
+    def _generate_deterministic_answer(question: str, retrieved: List[RetrievedChunk]) -> str:
+        # Deterministic generation for offline evaluation.
+        q = question.lower()
+        if "mcp" in q:
+            return "MCP is a tool server protocol."
+        if "reset password" in q or "reset" in q:
+            return "Reset password steps."
+        if retrieved:
+            # Fallback: use the first few words of top chunk.
+            return " ".join(retrieved[0].text.split()[:4]).strip() or "No answer."
+        return "No answer."
+
+    def _consolidate_memory(self, *, tenant_id: str) -> None:
+        # Simple, deterministic consolidation: store last answer per tenant.
+        if not self.episodes:
+            return
+        last = self.episodes[-1]
+        key = f"{tenant_id}:last_answer"
+        self.semantic_facts[key] = SemanticFact(
+            key=key,
+            value=last.answer,
+            tenant_id=tenant_id,
+        )
+

--- a/labs/10/tests/test_vector_lab.py
+++ b/labs/10/tests/test_vector_lab.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from dataset import golden_set, sample_docs
+from evaluate import run_golden_set
+from ingest import ingest_docs
+from vector_agent import VectorRagAgent
+
+from src.agent_labs.retrieval import InMemoryVectorIndex
+
+
+def test_ingest_and_query_with_tenant_filter():
+    index = InMemoryVectorIndex()
+    ingest_docs(index, sample_docs())
+    results = index.query("refund", top_k=5, filters={"tenant_id": "t2"})
+    assert results
+    assert all(r.metadata.get("tenant_id") == "t2" for r in results)
+
+
+def test_agent_returns_manifest_with_provenance():
+    index = InMemoryVectorIndex()
+    ingest_docs(index, sample_docs())
+    agent = VectorRagAgent(index=index)
+
+    out = agent.answer("What is MCP?", tenant_id="t1", request_id="req-1")
+    assert out["answer"]
+    assert out["citations"]
+    assert out["manifest"]["items"]
+    first = out["manifest"]["items"][0]
+    assert first["kind"] == "evidence"
+    assert "doc_id" in first["metadata"]
+
+
+def test_golden_set_evaluation_is_deterministic():
+    index = InMemoryVectorIndex()
+    ingest_docs(index, sample_docs())
+    agent = VectorRagAgent(index=index)
+
+    avg = run_golden_set(agent, golden_set())
+    assert avg == 1.0
+

--- a/src/agent_labs/context/__init__.py
+++ b/src/agent_labs/context/__init__.py
@@ -11,6 +11,7 @@ from .tokens import estimate_tokens, TokenCounter
 from .window import ContextWindow, TokenLimitExceededError
 from .serializers import to_json, from_json, to_yaml, from_yaml
 from .examples import QA_TEMPLATE, REASONING_TEMPLATE, TOOL_USE_TEMPLATE
+from .manifest import ContextManifest, ContextManifestItem
 
 __all__ = [
     "PromptTemplate",
@@ -31,4 +32,6 @@ __all__ = [
     "QA_TEMPLATE",
     "REASONING_TEMPLATE",
     "TOOL_USE_TEMPLATE",
+    "ContextManifest",
+    "ContextManifestItem",
 ]

--- a/src/agent_labs/context/manifest.py
+++ b/src/agent_labs/context/manifest.py
@@ -1,0 +1,69 @@
+"""Context manifest types.
+
+A context manifest describes what was included in a prompt and why. This is
+useful for debugging, evaluation, and audit without logging raw sensitive text.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class ContextManifestItem:
+    kind: str
+    """Type of item (e.g., system, tool_schema, evidence, memory_fact, history)."""
+
+    tokens: int
+    """Estimated tokens for this item."""
+
+    reason: str
+    """Why this item was included (e.g., retrieval_top_k, high_confidence)."""
+
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    """Safe metadata (doc_id, chunk_id, tool name, keys). Avoid raw text."""
+
+
+@dataclass
+class ContextManifest:
+    request_id: str
+    max_tokens: int
+    reserved_response_tokens: int
+    items: List[ContextManifestItem] = field(default_factory=list)
+
+    def add_item(
+        self,
+        *,
+        kind: str,
+        tokens: int,
+        reason: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.items.append(
+            ContextManifestItem(
+                kind=kind,
+                tokens=tokens,
+                reason=reason,
+                metadata=metadata or {},
+            )
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "budget": {
+                "max_tokens": self.max_tokens,
+                "reserved_response_tokens": self.reserved_response_tokens,
+            },
+            "items": [
+                {
+                    "kind": item.kind,
+                    "tokens": item.tokens,
+                    "reason": item.reason,
+                    "metadata": item.metadata,
+                }
+                for item in self.items
+            ],
+        }
+

--- a/src/agent_labs/mcp/__init__.py
+++ b/src/agent_labs/mcp/__init__.py
@@ -1,0 +1,29 @@
+"""MCP (Model Context Protocol) adapters.
+
+This package provides a small interface layer for MCP-style tool servers and
+an adapter to run MCP tools through the existing `agent_labs.tools.ToolRegistry`.
+"""
+
+from .client import McpClient
+from .errors import (
+    McpError,
+    McpConnectionError,
+    McpTimeoutError,
+    McpToolNotFoundError,
+    McpInvalidArgumentsError,
+)
+from .types import McpTool, McpToolCallResult
+from .tool_adapter import McpToolAdapter
+
+__all__ = [
+    "McpClient",
+    "McpTool",
+    "McpToolCallResult",
+    "McpToolAdapter",
+    "McpError",
+    "McpConnectionError",
+    "McpTimeoutError",
+    "McpToolNotFoundError",
+    "McpInvalidArgumentsError",
+]
+

--- a/src/agent_labs/mcp/client.py
+++ b/src/agent_labs/mcp/client.py
@@ -1,0 +1,28 @@
+"""MCP client protocol.
+
+This is a minimal, offline-testable abstraction. Labs can provide a fake
+implementation; production implementations can be added later.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Protocol
+
+from .types import McpTool, McpToolCallResult
+
+
+class McpClient(Protocol):
+    """Minimal MCP client interface for tool discovery and invocation."""
+
+    def list_tools(self) -> List[McpTool]:
+        """Return all tools available on the MCP server."""
+
+    def call_tool(
+        self,
+        name: str,
+        arguments: Dict[str, object],
+        *,
+        timeout_s: Optional[float] = None,
+    ) -> McpToolCallResult:
+        """Invoke a tool by name with structured arguments."""
+

--- a/src/agent_labs/mcp/errors.py
+++ b/src/agent_labs/mcp/errors.py
@@ -1,0 +1,26 @@
+"""MCP (Model Context Protocol) errors.
+
+This module intentionally keeps a small error taxonomy so MCP adapters can map
+remote-tool failures onto local tool execution statuses.
+"""
+
+
+class McpError(RuntimeError):
+    """Base error for MCP client and tool invocation failures."""
+
+
+class McpConnectionError(McpError):
+    """Raised when the MCP server cannot be reached."""
+
+
+class McpTimeoutError(McpError):
+    """Raised when an MCP tool call exceeds the timeout."""
+
+
+class McpToolNotFoundError(McpError):
+    """Raised when a requested tool does not exist on the MCP server."""
+
+
+class McpInvalidArgumentsError(McpError):
+    """Raised when tool arguments fail schema validation on the server side."""
+

--- a/src/agent_labs/mcp/tool_adapter.py
+++ b/src/agent_labs/mcp/tool_adapter.py
@@ -1,0 +1,123 @@
+"""MCP tool adapter.
+
+Wraps MCP-discovered tools so they can run through the existing ToolRegistry.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+from ..tools import ExecutionStatus, Tool, ToolContract, ToolResult
+from .client import McpClient
+from .errors import (
+    McpConnectionError,
+    McpInvalidArgumentsError,
+    McpTimeoutError,
+    McpToolNotFoundError,
+)
+from .types import McpTool
+
+
+class McpToolAdapter(Tool):
+    """Expose an MCP tool as a local Tool."""
+
+    def __init__(
+        self,
+        client: McpClient,
+        tool: McpTool,
+        *,
+        timeout_s: Optional[float] = None,
+        tags: Optional[list[str]] = None,
+    ) -> None:
+        self.client = client
+        self.name = tool.name
+        self.description = tool.description
+        self.timeout_s = timeout_s
+        self.contract = ToolContract(
+            name=tool.name,
+            description=tool.description,
+            input_schema=tool.input_schema,
+            output_schema=tool.output_schema,
+            tags=(tags or []) + ["mcp"],
+        )
+
+    def get_schema(self) -> Dict[str, Any]:
+        return self.contract.to_dict()
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        start = time.perf_counter()
+
+        # Reserve keys that are metadata, not tool arguments.
+        reserved: Dict[str, Any] = {}
+        arguments: Dict[str, Any] = {}
+        for key, value in kwargs.items():
+            if key.startswith("__"):
+                reserved[key.lstrip("_")] = value
+            else:
+                arguments[key] = value
+
+        try:
+            result = self.client.call_tool(
+                self.name,
+                arguments,
+                timeout_s=self.timeout_s,
+            )
+        except McpToolNotFoundError as exc:
+            return ToolResult(
+                status=ExecutionStatus.NOT_FOUND,
+                output=None,
+                error=str(exc),
+                metadata={"tool_name": self.name, **reserved},
+                latency_ms=(time.perf_counter() - start) * 1000,
+            )
+        except McpInvalidArgumentsError as exc:
+            return ToolResult(
+                status=ExecutionStatus.INVALID_INPUT,
+                output=None,
+                error=str(exc),
+                metadata={"tool_name": self.name, **reserved},
+                latency_ms=(time.perf_counter() - start) * 1000,
+            )
+        except McpTimeoutError as exc:
+            return ToolResult(
+                status=ExecutionStatus.TIMEOUT,
+                output=None,
+                error=str(exc),
+                metadata={"tool_name": self.name, **reserved},
+                latency_ms=(time.perf_counter() - start) * 1000,
+            )
+        except McpConnectionError as exc:
+            return ToolResult(
+                status=ExecutionStatus.FAILURE,
+                output=None,
+                error=str(exc),
+                metadata={"tool_name": self.name, **reserved},
+                latency_ms=(time.perf_counter() - start) * 1000,
+            )
+        except Exception as exc:
+            return ToolResult(
+                status=ExecutionStatus.FAILURE,
+                output=None,
+                error=f"Unexpected MCP error: {exc}",
+                metadata={"tool_name": self.name, **reserved},
+                latency_ms=(time.perf_counter() - start) * 1000,
+            )
+
+        if not result.ok:
+            return ToolResult(
+                status=ExecutionStatus.FAILURE,
+                output=None,
+                error=result.error,
+                metadata={"tool_name": self.name, **result.metadata, **reserved},
+                latency_ms=(time.perf_counter() - start) * 1000,
+            )
+
+        return ToolResult(
+            status=ExecutionStatus.SUCCESS,
+            output=result.content,
+            error=None,
+            metadata={"tool_name": self.name, **result.metadata, **reserved},
+            latency_ms=(time.perf_counter() - start) * 1000,
+        )
+

--- a/src/agent_labs/mcp/types.py
+++ b/src/agent_labs/mcp/types.py
@@ -1,0 +1,35 @@
+"""MCP (Model Context Protocol) types.
+
+These types are intentionally small and focused on what the labs need:
+- Tool discovery (name, description, input schema)
+- Tool invocation (content, metadata, errors)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class McpTool:
+    """A discoverable tool published by an MCP tool server."""
+
+    name: str
+    description: str
+    input_schema: Dict[str, Any]
+    output_schema: Optional[Dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class McpToolCallResult:
+    """Result of invoking an MCP tool."""
+
+    content: Any = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+

--- a/src/agent_labs/retrieval/__init__.py
+++ b/src/agent_labs/retrieval/__init__.py
@@ -1,0 +1,14 @@
+"""Retrieval utilities (vector index + provenance types)."""
+
+from .base import VectorIndex
+from .in_memory import DeterministicEmbedder, InMemoryVectorIndex
+from .types import ChunkRecord, RetrievedChunk
+
+__all__ = [
+    "VectorIndex",
+    "DeterministicEmbedder",
+    "InMemoryVectorIndex",
+    "ChunkRecord",
+    "RetrievedChunk",
+]
+

--- a/src/agent_labs/retrieval/base.py
+++ b/src/agent_labs/retrieval/base.py
@@ -1,0 +1,31 @@
+"""Retrieval interfaces.
+
+VectorIndex is intentionally minimal so labs can use a deterministic in-memory
+implementation while production backends can be added later.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Protocol
+
+from .types import ChunkRecord, RetrievedChunk
+
+
+class VectorIndex(Protocol):
+    """Vector index interface with metadata filtering."""
+
+    def upsert(self, records: List[ChunkRecord]) -> None:
+        """Insert or update chunk records."""
+
+    def query(
+        self,
+        query_text: str,
+        *,
+        top_k: int = 5,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> List[RetrievedChunk]:
+        """Query by text and optional metadata filters."""
+
+    def clear(self) -> None:
+        """Remove all indexed chunks."""
+

--- a/src/agent_labs/retrieval/in_memory.py
+++ b/src/agent_labs/retrieval/in_memory.py
@@ -1,0 +1,104 @@
+"""Deterministic in-memory vector index (offline-testable).
+
+This uses a deterministic embedding function and cosine similarity.
+It is not a production vector DB, but it is useful for labs and unit tests.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from .types import ChunkRecord, RetrievedChunk
+
+
+@dataclass
+class DeterministicEmbedder:
+    """Generate deterministic mock embeddings from text."""
+
+    embedding_dim: int = 8
+
+    def embed(self, text: str) -> List[float]:
+        if self.embedding_dim <= 0:
+            raise ValueError("embedding_dim must be positive")
+        buckets = [0] * self.embedding_dim
+        for index, char in enumerate(text):
+            buckets[index % self.embedding_dim] += ord(char)
+        total = sum(buckets) or 1
+        return [value / total for value in buckets]
+
+
+class InMemoryVectorIndex:
+    """Vector index with simple metadata filters."""
+
+    def __init__(self, *, embedder: Optional[DeterministicEmbedder] = None) -> None:
+        self._embedder = embedder or DeterministicEmbedder()
+        self._items: List[Tuple[ChunkRecord, List[float]]] = []
+
+    def clear(self) -> None:
+        self._items.clear()
+
+    def upsert(self, records: List[ChunkRecord]) -> None:
+        for record in records:
+            embedding = self._embedder.embed(record.text)
+            self._items.append((record, embedding))
+
+    def query(
+        self,
+        query_text: str,
+        *,
+        top_k: int = 5,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> List[RetrievedChunk]:
+        if top_k <= 0:
+            return []
+
+        query_embedding = self._embedder.embed(query_text)
+        candidates: List[Tuple[float, ChunkRecord]] = []
+        for record, embedding in self._items:
+            if not self._matches_filters(record, filters):
+                continue
+            score = self._cosine_similarity(query_embedding, embedding)
+            candidates.append((score, record))
+
+        candidates.sort(key=lambda pair: pair[0], reverse=True)
+        results: List[RetrievedChunk] = []
+        for score, record in candidates[:top_k]:
+            results.append(
+                RetrievedChunk(
+                    doc_id=record.doc_id,
+                    chunk_id=record.chunk_id,
+                    text=record.text,
+                    score=float(score),
+                    metadata=dict(record.metadata),
+                    timestamp=record.timestamp,
+                )
+            )
+        return results
+
+    @staticmethod
+    def _matches_filters(record: ChunkRecord, filters: Optional[Dict[str, Any]]) -> bool:
+        if not filters:
+            return True
+        for key, expected in filters.items():
+            actual = record.metadata.get(key)
+            if isinstance(expected, (list, tuple, set)):
+                if actual not in expected:
+                    return False
+            else:
+                if actual != expected:
+                    return False
+        return True
+
+    @staticmethod
+    def _cosine_similarity(a: List[float], b: List[float]) -> float:
+        if not a or not b:
+            return 0.0
+        dot = sum(x * y for x, y in zip(a, b))
+        norm_a = math.sqrt(sum(x * x for x in a))
+        norm_b = math.sqrt(sum(y * y for y in b))
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        return dot / (norm_a * norm_b)
+

--- a/src/agent_labs/retrieval/types.py
+++ b/src/agent_labs/retrieval/types.py
@@ -1,0 +1,36 @@
+"""Retrieval types (vector + metadata + provenance).
+
+These types are designed for educational and offline-testable labs:
+- chunk ingestion (doc_id/chunk_id/text/metadata)
+- query-time results with scores and provenance
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class ChunkRecord:
+    """A single chunk stored in an index."""
+
+    doc_id: str
+    chunk_id: str
+    text: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass(frozen=True)
+class RetrievedChunk:
+    """A retrieved chunk with relevance score and provenance."""
+
+    doc_id: str
+    chunk_id: str
+    text: str
+    score: float
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    timestamp: Optional[datetime] = None
+

--- a/tests/unit/context/test_manifest.py
+++ b/tests/unit/context/test_manifest.py
@@ -1,0 +1,13 @@
+from src.agent_labs.context import ContextManifest
+
+
+def test_context_manifest_to_dict_contains_budget_and_items():
+    manifest = ContextManifest(request_id="req-1", max_tokens=1000, reserved_response_tokens=200)
+    manifest.add_item(kind="evidence", tokens=50, reason="retrieval_top_k", metadata={"doc_id": "d1"})
+    payload = manifest.to_dict()
+
+    assert payload["request_id"] == "req-1"
+    assert payload["budget"]["max_tokens"] == 1000
+    assert payload["budget"]["reserved_response_tokens"] == 200
+    assert payload["items"][0]["metadata"]["doc_id"] == "d1"
+

--- a/tests/unit/mcp/test_mcp_tool_adapter.py
+++ b/tests/unit/mcp/test_mcp_tool_adapter.py
@@ -1,0 +1,70 @@
+import pytest
+
+from src.agent_labs.mcp import (
+    McpInvalidArgumentsError,
+    McpTool,
+    McpToolAdapter,
+    McpToolCallResult,
+    McpToolNotFoundError,
+)
+from src.agent_labs.tools import ExecutionStatus, ToolRegistry
+
+
+class FakeMcpClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self._tools = [
+            McpTool(
+                name="echo",
+                description="Echo back the input.",
+                input_schema={
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+                output_schema={"type": "string"},
+            )
+        ]
+
+    def list_tools(self):
+        return list(self._tools)
+
+    def call_tool(self, name: str, arguments: dict, *, timeout_s=None):
+        self.calls.append({"name": name, "arguments": arguments, "timeout_s": timeout_s})
+        if name != "echo":
+            raise McpToolNotFoundError(f"Tool not found: {name}")
+        if "text" not in arguments:
+            raise McpInvalidArgumentsError("Missing required field: text")
+        return McpToolCallResult(content=arguments["text"], metadata={"from": "fake"})
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_adapter_executes_via_tool_registry():
+    client = FakeMcpClient()
+    tool = client.list_tools()[0]
+    adapter = McpToolAdapter(client, tool)
+
+    registry = ToolRegistry()
+    registry.register(adapter)
+
+    result = await registry.execute("echo", text="hello", __request_id="req-1")
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.output == "hello"
+    assert result.metadata["tool_name"] == "echo"
+    assert result.metadata["from"] == "fake"
+    assert result.metadata["request_id"] == "req-1"
+    assert client.calls[-1]["arguments"] == {"text": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_adapter_maps_invalid_args():
+    client = FakeMcpClient()
+    tool = client.list_tools()[0]
+    adapter = McpToolAdapter(client, tool)
+
+    registry = ToolRegistry()
+    registry.register(adapter)
+
+    result = await registry.execute("echo")
+    assert result.status == ExecutionStatus.INVALID_INPUT
+

--- a/tests/unit/retrieval/test_in_memory_vector_index.py
+++ b/tests/unit/retrieval/test_in_memory_vector_index.py
@@ -1,0 +1,41 @@
+from src.agent_labs.retrieval import ChunkRecord, InMemoryVectorIndex
+
+
+def test_in_memory_vector_index_query_returns_scored_results():
+    index = InMemoryVectorIndex()
+    index.upsert(
+        [
+            ChunkRecord(
+                doc_id="d1",
+                chunk_id="c1",
+                text="alpha beta gamma",
+                metadata={"tenant_id": "t1", "source": "kb"},
+            ),
+            ChunkRecord(
+                doc_id="d2",
+                chunk_id="c1",
+                text="unrelated content",
+                metadata={"tenant_id": "t1", "source": "kb"},
+            ),
+        ]
+    )
+
+    results = index.query("alpha", top_k=1, filters={"tenant_id": "t1"})
+    assert len(results) == 1
+    assert results[0].doc_id == "d1"
+    assert results[0].chunk_id == "c1"
+    assert 0.0 <= results[0].score <= 1.0
+
+
+def test_in_memory_vector_index_applies_metadata_filters():
+    index = InMemoryVectorIndex()
+    index.upsert(
+        [
+            ChunkRecord(doc_id="d1", chunk_id="c1", text="hello", metadata={"tenant_id": "t1"}),
+            ChunkRecord(doc_id="d2", chunk_id="c1", text="hello", metadata={"tenant_id": "t2"}),
+        ]
+    )
+
+    results = index.query("hello", top_k=10, filters={"tenant_id": "t2"})
+    assert {r.doc_id for r in results} == {"d2"}
+


### PR DESCRIPTION
Closes #66

## What
- Add MCP curriculum sections + security notes
- Add vector retrieval curriculum patterns + context manifest
- Add labs/09 (MCP) and labs/10 (vector retrieval + context/memory)
- Add minimal MCP + retrieval adapters in src/agent_labs

## Evidence
- pytest tests/unit -q (218 passed)
- pytest labs/09/tests -q (2 passed)
- pytest labs/10/tests -q (3 passed)