### PR TITLE
feat(agent_core): configuration system (closes #90)

### DIFF
--- a/src/agent_core/__init__.py
+++ b/src/agent_core/__init__.py
@@ -1,0 +1,5 @@
+"""Production framework core package."""
+
+from .config import AgentCoreConfig, load_config
+
+__all__ = ["AgentCoreConfig", "load_config"]

--- a/src/agent_core/config/__init__.py
+++ b/src/agent_core/config/__init__.py
@@ -1,0 +1,6 @@
+"""Configuration system for agent_core."""
+
+from .loader import load_config
+from .models import AgentCoreConfig
+
+__all__ = ["AgentCoreConfig", "load_config"]

--- a/src/agent_core/config/loader.py
+++ b/src/agent_core/config/loader.py
@@ -1,0 +1,102 @@
+"""Config loader for agent_core."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+from dotenv import load_dotenv
+
+from .models import AgentCoreConfig
+
+
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    result = dict(base)
+    for key, value in override.items():
+        if (
+            key in result
+            and isinstance(result[key], dict)
+            and isinstance(value, dict)
+        ):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _parse_env_value(value: str) -> Any:
+    lowered = value.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    if lowered == "none":
+        return None
+    try:
+        if "." in value:
+            return float(value)
+        return int(value)
+    except ValueError:
+        return value
+
+
+def _set_nested(target: Dict[str, Any], keys: list[str], value: Any) -> None:
+    current = target
+    for key in keys[:-1]:
+        current = current.setdefault(key, {})
+    current[keys[-1]] = value
+
+
+def _env_to_dict(prefix: str, environ: Dict[str, str]) -> Dict[str, Any]:
+    data: Dict[str, Any] = {}
+    for key, value in environ.items():
+        if not key.startswith(prefix):
+            continue
+        path = key[len(prefix) :].strip("_")
+        if not path:
+            continue
+        parts = path.split("__")
+        parts = [p.lower() for p in parts if p]
+        _set_nested(data, parts, _parse_env_value(value))
+    return data
+
+
+def _load_file(path: str) -> Dict[str, Any]:
+    if path.lower().endswith(".json"):
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    if path.lower().endswith((".yaml", ".yml")):
+        try:
+            import yaml
+        except ImportError as exc:
+            raise RuntimeError("PyYAML is required for YAML config files.") from exc
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    raise ValueError(f"Unsupported config file type: {path}")
+
+
+def load_config(
+    path: Optional[str] = None,
+    overrides: Optional[Dict[str, Any]] = None,
+    env_prefix: str = "AGENT_CORE_",
+    load_dotenv_file: bool = True,
+) -> AgentCoreConfig:
+    if load_dotenv_file:
+        load_dotenv()
+
+    base = AgentCoreConfig().model_dump()
+
+    data: Dict[str, Any] = {}
+    if path is None:
+        path = os.getenv(f"{env_prefix}CONFIG_PATH")
+    if path:
+        data = _load_file(path)
+
+    env_data = _env_to_dict(env_prefix, os.environ)
+    merged = _deep_merge(base, data)
+    merged = _deep_merge(merged, env_data)
+    if overrides:
+        merged = _deep_merge(merged, overrides)
+
+    config = AgentCoreConfig(**merged)
+    config.validate_deterministic()
+    return config

--- a/src/agent_core/config/models.py
+++ b/src/agent_core/config/models.py
@@ -1,0 +1,122 @@
+"""Configuration models for agent_core."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AppConfig(BaseModel):
+    name: str = "agent_core_app"
+    environment: str = "local"
+
+
+class EngineConfig(BaseModel):
+    key: str = "local"
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ModelSpec(BaseModel):
+    provider: str
+    model: str
+    base_url: Optional[str] = None
+    api_key_env: Optional[str] = None
+    timeout_s: Optional[float] = None
+    capabilities: Optional[List[str]] = None
+
+
+class ModelsConfig(BaseModel):
+    roles: Dict[str, ModelSpec] = Field(default_factory=dict)
+
+
+class ToolsConfig(BaseModel):
+    allowlist: List[str] = Field(default_factory=list)
+    providers: Dict[str, Any] = Field(default_factory=dict)
+
+
+class BackendConfig(BaseModel):
+    backend: str
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RetrievalConfig(BaseModel):
+    gating: str = "none"
+    vectorstore: BackendConfig = Field(default_factory=lambda: BackendConfig(backend="memory"))
+
+
+class MemoryConfig(BaseModel):
+    session_store: BackendConfig = Field(default_factory=lambda: BackendConfig(backend="memory"))
+    long_term_store: BackendConfig = Field(default_factory=lambda: BackendConfig(backend="disabled"))
+    run_store: BackendConfig = Field(default_factory=lambda: BackendConfig(backend="memory"))
+
+
+class BudgetsConfig(BaseModel):
+    max_tool_calls: int = 0
+    max_run_seconds: int = 0
+    max_total_tokens: int = 0
+
+
+class PoliciesConfig(BaseModel):
+    read_only: bool = True
+    budgets: BudgetsConfig = Field(default_factory=BudgetsConfig)
+
+
+class RedactConfig(BaseModel):
+    pii: bool = True
+    secrets: bool = True
+
+
+class ObservabilityConfig(BaseModel):
+    exporter: str = "stdout_json"
+    redact: RedactConfig = Field(default_factory=RedactConfig)
+
+
+class GateConfig(BaseModel):
+    min_average_score: float = 0.0
+    max_regression: float = 0.0
+
+
+class EvaluationConfig(BaseModel):
+    enabled: bool = False
+    gate: GateConfig = Field(default_factory=GateConfig)
+
+
+class ArtifactsConfig(BaseModel):
+    store: BackendConfig = Field(default_factory=lambda: BackendConfig(backend="filesystem"))
+
+
+class AuthConfig(BaseModel):
+    mode: str = "none"
+
+
+class ServiceConfig(BaseModel):
+    enabled: bool = False
+    host: str = "127.0.0.1"
+    port: int = 8080
+    auth: AuthConfig = Field(default_factory=AuthConfig)
+
+
+class AgentCoreConfig(BaseModel):
+    app: AppConfig = Field(default_factory=AppConfig)
+    mode: str = "real"
+    engine: EngineConfig = Field(default_factory=EngineConfig)
+    models: ModelsConfig = Field(default_factory=ModelsConfig)
+    tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    retrieval: RetrievalConfig = Field(default_factory=RetrievalConfig)
+    memory: MemoryConfig = Field(default_factory=MemoryConfig)
+    policies: PoliciesConfig = Field(default_factory=PoliciesConfig)
+    observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
+    evaluation: EvaluationConfig = Field(default_factory=EvaluationConfig)
+    artifacts: ArtifactsConfig = Field(default_factory=ArtifactsConfig)
+    service: ServiceConfig = Field(default_factory=ServiceConfig)
+
+    def validate_deterministic(self) -> None:
+        if self.mode != "deterministic":
+            return
+        for role, spec in self.models.roles.items():
+            if spec.provider not in {"mock"}:
+                raise ValueError(
+                    f"Deterministic mode requires mock providers. "
+                    f"Role '{role}' uses provider '{spec.provider}'."
+                )

--- a/tests/integration/test_agent_core_config_ollama.py
+++ b/tests/integration/test_agent_core_config_ollama.py
@@ -1,0 +1,58 @@
+"""
+Integration tests for agent_core config with Ollama.
+
+Requires:
+- Ollama running at http://localhost:11434
+- A phi* or llama2 model installed
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import httpx
+
+from agent_core.config import load_config
+
+
+pytestmark = pytest.mark.ollama
+
+SKIP_OLLAMA = os.getenv("SKIP_OLLAMA", "false").lower() == "true"
+
+
+def _get_available_models(base_url: str) -> list[str]:
+    try:
+        resp = httpx.get(f"{base_url}/api/tags", timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+        return [m.get("name", "") for m in data.get("models", [])]
+    except Exception:
+        return []
+
+
+def _select_model(names: list[str]) -> str | None:
+    for name in names:
+        if name.startswith("phi") or name == "llama2" or name.startswith("llama2:"):
+            return name
+    return None
+
+
+@pytest.mark.skipif(SKIP_OLLAMA, reason="Ollama tests disabled (set SKIP_OLLAMA=false to run)")
+def test_load_config_with_ollama_role(monkeypatch):
+    base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    models = _get_available_models(base_url)
+    selected = _select_model(models)
+    if not selected:
+        pytest.skip("No phi* or llama2 model found in Ollama. Pull one to run this test.")
+
+    monkeypatch.setenv("AGENT_CORE_MODE", "real")
+    monkeypatch.setenv("AGENT_CORE_MODELS__ROLES__ACTOR__PROVIDER", "ollama")
+    monkeypatch.setenv("AGENT_CORE_MODELS__ROLES__ACTOR__MODEL", selected)
+    monkeypatch.setenv("AGENT_CORE_MODELS__ROLES__ACTOR__BASE_URL", base_url)
+
+    config = load_config(load_dotenv_file=False)
+    assert config.mode == "real"
+    assert config.models.roles["actor"].provider == "ollama"
+    assert config.models.roles["actor"].model == selected
+    assert config.models.roles["actor"].base_url == base_url

--- a/tests/unit/agent_core/test_config.py
+++ b/tests/unit/agent_core/test_config.py
@@ -1,0 +1,54 @@
+"""Tests for agent_core configuration loading."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from agent_core.config import AgentCoreConfig, load_config
+
+
+def test_default_config_constructs():
+    config = AgentCoreConfig()
+    assert config.app.name == "agent_core_app"
+    assert config.engine.key == "local"
+    assert config.mode == "real"
+
+
+def test_load_config_from_json(tmp_path: Path):
+    config_path = tmp_path / "config.json"
+    data = {
+        "app": {"name": "test_app", "environment": "local"},
+        "mode": "deterministic",
+        "models": {"roles": {"actor": {"provider": "mock", "model": "det"}}},
+    }
+    config_path.write_text(json.dumps(data), encoding="utf-8")
+
+    config = load_config(path=str(config_path))
+    assert config.app.name == "test_app"
+    assert config.mode == "deterministic"
+    assert config.models.roles["actor"].provider == "mock"
+
+
+def test_env_override(monkeypatch):
+    monkeypatch.setenv("AGENT_CORE_MODELS__ROLES__ACTOR__PROVIDER", "mock")
+    monkeypatch.setenv("AGENT_CORE_MODELS__ROLES__ACTOR__MODEL", "det")
+    monkeypatch.setenv("AGENT_CORE_MODE", "deterministic")
+
+    config = load_config(load_dotenv_file=False)
+    assert config.mode == "deterministic"
+    assert config.models.roles["actor"].provider == "mock"
+    assert config.models.roles["actor"].model == "det"
+
+
+def test_deterministic_validation_requires_mock(monkeypatch):
+    monkeypatch.setenv("AGENT_CORE_MODE", "deterministic")
+    monkeypatch.setenv("AGENT_CORE_MODELS__ROLES__ACTOR__PROVIDER", "ollama")
+    monkeypatch.setenv("AGENT_CORE_MODELS__ROLES__ACTOR__MODEL", "llama")
+
+    with pytest.raises(ValueError, match="Deterministic mode requires mock"):
+        load_config(load_dotenv_file=False)
+


### PR DESCRIPTION
## Description

Implement agent_core configuration system (models + loader) with env overrides and deterministic validation. Add unit tests and an Ollama integration test for real-provider configuration.

Closes #90

## Changes

- Add `agent_core` config models and loader with environment override support
- Add deterministic validation for mock-only mode
- Add unit tests and Ollama integration test (phi/llama2)

## Evidence Mapping

| Criterion | Test | Location | Status |
|-----------|------|----------|--------|
| 1. Implementation matches the design pack | Manual review vs design pack | `src/agent_core/config/models.py`, `src/agent_core/config/loader.py` | ? |
| 2. Deterministic tests added/updated | `pytest tests/unit/agent_core/test_config.py -v` | Local run (see PR notes) | ? |
| 3. Documentation updated where required | Not required for this story | N/A | ? |

## Checklist

### Code Quality
- [x] All acceptance criteria met with evidence above
- [x] Tests added and passing
- [ ] No regressions (existing tests pass)
- [x] Code follows project conventions
- [x] No debug statements or commented code

### Documentation
- [ ] README updated (if applicable)
- [ ] API docs updated (if applicable)
- [ ] Code comments for complex logic

### Process
- [x] PR linked to story (`Closes #`)
- [x] Branch follows naming convention
- [ ] Branch up to date with main
- [x] Self-reviewed the diff

## Screenshots (if UI change)

| Before | After |
|--------|-------|
| | |

## Notes for Reviewers

Test evidence:
- `pytest tests/unit/agent_core/test_config.py -v`
- `pytest tests/integration/test_agent_core_config_ollama.py -v -m ollama`

---

**For Reviewer:** Validate evidence mapping before approving.
**For CODEOWNER:** Run pre-merge checklist before merging.
