### PR TITLE
feat(story-94): tool executor & contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Labs are the hands-on companion to the knowledge base and curriculum:
   - `90_supporting/` — Glossary and mappings
 - `chapters/`, `curriculum/` — Additional/legacy structure (in progress)
 
+## Agent Core Docs
+
+- Tool contracts and executor: `docs/tools.md`
+
+
 ## Labs Architecture (Planned)
 
 ### Shared Core: `src/agent_labs/`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,111 @@
+# Tools
+
+This document describes tool contracts, the ToolExecutor policy boundary, and built-in tools.
+
+## ToolContract schema
+
+Tool contracts describe a tool's interface and governance requirements.
+
+Required fields:
+- `name`
+- `version`
+- `description`
+- `risk` (`read`, `write`, `admin`)
+- `input_schema` (JSON Schema)
+- `output_schema` (JSON Schema)
+- `required_scopes`
+- `idempotency` (required for write/admin)
+- `data_handling` (PII/secrets logging constraints)
+
+Example:
+
+```python
+from agent_core.tools import ToolContract, ToolIdempotency, ToolDataHandling, RiskLevel
+
+contract = ToolContract(
+    name="calculator",
+    description="Perform basic arithmetic operations.",
+    version="1.0.0",
+    risk=RiskLevel.READ,
+    input_schema={
+        "type": "object",
+        "properties": {
+            "operation": {"type": "string"},
+            "a": {"type": "number"},
+            "b": {"type": "number"},
+        },
+        "required": ["operation", "a", "b"],
+    },
+    output_schema={
+        "type": "object",
+        "properties": {"value": {"type": "number"}},
+        "required": ["value"],
+    },
+    required_scopes=[],
+    idempotency=ToolIdempotency(required=False),
+    data_handling=ToolDataHandling(pii=False, secrets=False),
+)
+```
+
+## ToolExecutor policy enforcement
+
+All tool calls flow through `ToolExecutor`, which enforces:
+- Allowlist (deny-by-default)
+- Input validation (JSON Schema)
+- Read-only policy (blocks write/admin)
+- Timeouts (per call or per contract)
+- Error normalization
+- Audit events (`tool.call.started`, `tool.call.finished`, `tool.call.blocked`)
+
+## Minimal usage
+
+```python
+from agent_core import AgentCoreConfig
+from agent_core.config.models import ToolsConfig
+from agent_core.factories import EngineFactory, ToolExecutorFactory
+from agent_core.registry import get_global_registry
+
+registry = get_global_registry()
+config = AgentCoreConfig(
+    tools=ToolsConfig(allowlist=["calculator"]),
+)
+
+tool_factory = ToolExecutorFactory(registry.tool_providers)
+engine_factory = EngineFactory(registry.engines)
+engine = engine_factory.build_with_config(config, tool_executor_factory=tool_factory)
+```
+
+## Add a custom tool
+
+1. Create a tool class with a `ToolContract`.
+2. Implement `async execute(**kwargs) -> ToolResult`.
+3. Register it in a `ToolProvider`.
+
+Example:
+
+```python
+from agent_core.tools import ToolContract, ToolResult, ExecutionStatus, RiskLevel
+
+class MyTool:
+    def __init__(self) -> None:
+        self.contract = ToolContract(
+            name="my_tool",
+            description="Custom tool.",
+            version="1.0.0",
+            risk=RiskLevel.READ,
+            input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+            output_schema={"type": "object", "properties": {"result": {"type": "string"}}},
+        )
+
+    async def execute(self, **kwargs) -> ToolResult:
+        return ToolResult(
+            status=ExecutionStatus.SUCCESS,
+            output={"result": "ok"},
+        )
+```
+
+## Built-in tools
+
+- `calculator`: basic arithmetic operations.
+- `web_search`: mock search provider (deterministic results).
+- `file_read`: read text files from disk (read-only).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pydantic>=2.0",
     "httpx>=0.24.0",
     "python-dotenv>=1.0",
+    "jsonschema>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/agent_core/__init__.py
+++ b/src/agent_core/__init__.py
@@ -8,7 +8,7 @@ from .exceptions import (
     PluginNotFoundError,
     RegistryError,
 )
-from .factories import EngineFactory, ModelFactory, ToolProviderFactory
+from .factories import EngineFactory, ModelFactory, ToolExecutorFactory, ToolProviderFactory
 from .model import ModelClient, ModelMessage, ModelResponse, ModelUsage, ToolCall, normalize_messages
 from .plugin_loader import ENTRY_POINT_GROUP, load_plugin
 from .registry import (
@@ -42,11 +42,14 @@ __all__ = [
     "Registry",
     "RegistryError",
     "ToolProviderFactory",
+    "ToolExecutorFactory",
     "ToolCall",
     "ToolProviderRegistry",
+    "ToolExecutor",
     "VectorStoreRegistry",
     "get_global_registry",
     "load_config",
     "load_plugin",
     "normalize_messages",
 ]
+from .tools import ToolExecutor

--- a/src/agent_core/builtins.py
+++ b/src/agent_core/builtins.py
@@ -2,19 +2,9 @@
 
 from __future__ import annotations
 
-from .providers import FixtureToolProvider, MockProvider, OllamaProvider, OpenAIProvider
-
-
-class LocalEngine:
-    """Stub execution engine placeholder."""
-
-
-class NativeToolProvider:
-    """Stub tool provider placeholder."""
-
-
-class McpToolProvider:
-    """Stub MCP tool provider placeholder."""
+from .engine import LocalEngine
+from .providers import MockProvider, OllamaProvider, OpenAIProvider
+from .tools import FixtureToolProviderAdapter, McpToolProvider, NativeToolProvider
 
 
 class MemoryVectorStore:
@@ -35,7 +25,7 @@ class MemoryExporter:
 
 __all__ = [
     "FileExporter",
-    "FixtureToolProvider",
+    "FixtureToolProviderAdapter",
     "LocalEngine",
     "McpToolProvider",
     "MemoryExporter",

--- a/src/agent_core/engine.py
+++ b/src/agent_core/engine.py
@@ -1,0 +1,20 @@
+"""Local execution engine."""
+
+from __future__ import annotations
+
+from .tools import ToolCall, ToolExecutor, ToolResult
+
+
+class LocalEngine:
+    """Minimal local engine for executing tool calls."""
+
+    def __init__(self, tool_executor: ToolExecutor | None = None) -> None:
+        self.tool_executor = tool_executor
+
+    async def execute_tool(self, call: ToolCall) -> ToolResult:
+        if self.tool_executor is None:
+            raise RuntimeError("ToolExecutor not configured.")
+        return await self.tool_executor.execute(call)
+
+
+__all__ = ["LocalEngine"]

--- a/src/agent_core/providers/fixture_tools.py
+++ b/src/agent_core/providers/fixture_tools.py
@@ -43,6 +43,9 @@ class FixtureToolProvider:
             )
         return fixture.result
 
+    def list_fixtures(self) -> list[ToolFixture]:
+        return list(self._fixtures.values())
+
     def _load_fixtures(self, path: Path) -> dict[tuple[str, str, str], ToolFixture]:
         fixtures: dict[tuple[str, str, str], ToolFixture] = {}
         if path.is_dir():

--- a/src/agent_core/registry.py
+++ b/src/agent_core/registry.py
@@ -110,7 +110,7 @@ _MODEL_PROVIDER_REGISTRY.register("openai", builtins.OpenAIProvider)
 
 _TOOL_PROVIDER_REGISTRY.register("native", builtins.NativeToolProvider)
 _TOOL_PROVIDER_REGISTRY.register("mcp", builtins.McpToolProvider)
-_TOOL_PROVIDER_REGISTRY.register("fixture", builtins.FixtureToolProvider)
+_TOOL_PROVIDER_REGISTRY.register("fixture", builtins.FixtureToolProviderAdapter)
 
 _VECTORSTORE_REGISTRY.register("memory", builtins.MemoryVectorStore)
 

--- a/src/agent_core/tools/__init__.py
+++ b/src/agent_core/tools/__init__.py
@@ -1,0 +1,40 @@
+"""Tooling interfaces and implementations for agent_core."""
+
+from .contract import (
+    ExecutionStatus,
+    RiskLevel,
+    ToolCall,
+    ToolConstraints,
+    ToolContract,
+    ToolDataHandling,
+    ToolError,
+    ToolIdempotency,
+    ToolPermissions,
+    ToolResult,
+    TraceContext,
+)
+from .executor import ToolExecutor
+from .fixture import FixtureToolProviderAdapter
+from .mcp import McpToolProvider
+from .native import NativeToolProvider
+from .provider import Tool, ToolProvider
+
+__all__ = [
+    "ExecutionStatus",
+    "RiskLevel",
+    "Tool",
+    "ToolCall",
+    "ToolConstraints",
+    "ToolContract",
+    "ToolDataHandling",
+    "ToolError",
+    "ToolExecutor",
+    "ToolIdempotency",
+    "ToolPermissions",
+    "ToolProvider",
+    "ToolResult",
+    "TraceContext",
+    "FixtureToolProviderAdapter",
+    "McpToolProvider",
+    "NativeToolProvider",
+]

--- a/src/agent_core/tools/builtin/__init__.py
+++ b/src/agent_core/tools/builtin/__init__.py
@@ -1,0 +1,7 @@
+"""Built-in tool implementations for agent_core."""
+
+from .calculator import CalculatorTool
+from .file_read import FileReadTool
+from .web_search import WebSearchTool
+
+__all__ = ["CalculatorTool", "FileReadTool", "WebSearchTool"]

--- a/src/agent_core/tools/builtin/calculator.py
+++ b/src/agent_core/tools/builtin/calculator.py
@@ -1,0 +1,72 @@
+"""Built-in calculator tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..contract import ExecutionStatus, RiskLevel, ToolContract, ToolResult
+
+
+class CalculatorTool:
+    """Perform basic arithmetic operations."""
+
+    def __init__(self) -> None:
+        self.contract = ToolContract(
+            name="calculator",
+            description="Perform basic arithmetic operations.",
+            version="1.0.0",
+            risk=RiskLevel.READ,
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "operation": {
+                        "type": "string",
+                        "enum": ["add", "subtract", "multiply", "divide"],
+                    },
+                    "a": {"type": "number"},
+                    "b": {"type": "number"},
+                },
+                "required": ["operation", "a", "b"],
+            },
+            output_schema={
+                "type": "object",
+                "properties": {"value": {"type": "number"}},
+                "required": ["value"],
+            },
+            metadata={"category": "math"},
+        )
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        operation = kwargs.get("operation")
+        a = kwargs.get("a")
+        b = kwargs.get("b")
+
+        try:
+            if operation == "add":
+                value = a + b
+            elif operation == "subtract":
+                value = a - b
+            elif operation == "multiply":
+                value = a * b
+            elif operation == "divide":
+                if b == 0:
+                    raise ZeroDivisionError("Division by zero.")
+                value = a / b
+            else:
+                raise ValueError(f"Unsupported operation '{operation}'.")
+        except Exception as exc:  # pragma: no cover - exercised via executor error mapping
+            return ToolResult(
+                status=ExecutionStatus.FAILURE,
+                error=None,
+                output=None,
+                metadata={"error": str(exc)},
+            )
+
+        return ToolResult(
+            status=ExecutionStatus.SUCCESS,
+            output={"value": value},
+            metadata={"tool_version": self.contract.version},
+        )
+
+
+__all__ = ["CalculatorTool"]

--- a/src/agent_core/tools/builtin/file_read.py
+++ b/src/agent_core/tools/builtin/file_read.py
@@ -1,0 +1,81 @@
+"""Built-in file read tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..contract import ExecutionStatus, RiskLevel, ToolContract, ToolConstraints, ToolResult
+
+
+class FileReadTool:
+    """Read text files from disk."""
+
+    def __init__(self, max_lines: int = 200) -> None:
+        self._max_lines = max_lines
+        self.contract = ToolContract(
+            name="file_read",
+            description="Read a text file from disk.",
+            version="1.0.0",
+            risk=RiskLevel.READ,
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "start_line": {"type": "integer", "minimum": 1},
+                    "end_line": {"type": "integer", "minimum": 1},
+                },
+                "required": ["path"],
+            },
+            output_schema={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"},
+                    "start_line": {"type": "integer"},
+                    "end_line": {"type": "integer"},
+                },
+                "required": ["path", "content", "start_line", "end_line"],
+            },
+            constraints=ToolConstraints(requires_file_access=True),
+            metadata={"category": "filesystem"},
+        )
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        path_value = kwargs.get("path")
+        if not path_value:
+            return ToolResult(status=ExecutionStatus.FAILURE, output=None)
+
+        path = Path(str(path_value))
+        try:
+            content = path.read_text(encoding="utf-8")
+        except Exception as exc:  # pragma: no cover - error mapping in executor
+            return ToolResult(
+                status=ExecutionStatus.FAILURE,
+                output=None,
+                metadata={"error": str(exc)},
+            )
+
+        lines = content.splitlines()
+        start_line = int(kwargs.get("start_line") or 1)
+        end_line = int(kwargs.get("end_line") or min(len(lines), start_line + self._max_lines - 1))
+        end_line = min(end_line, start_line + self._max_lines - 1, len(lines))
+        if start_line > len(lines):
+            start_line = len(lines)
+        if end_line < start_line:
+            end_line = start_line
+
+        sliced = lines[start_line - 1 : end_line]
+        return ToolResult(
+            status=ExecutionStatus.SUCCESS,
+            output={
+                "path": str(path),
+                "content": "\n".join(sliced),
+                "start_line": start_line,
+                "end_line": end_line,
+            },
+            metadata={"tool_version": self.contract.version},
+        )
+
+
+__all__ = ["FileReadTool"]

--- a/src/agent_core/tools/builtin/web_search.py
+++ b/src/agent_core/tools/builtin/web_search.py
@@ -1,0 +1,70 @@
+"""Built-in web search tool (mock)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..contract import ExecutionStatus, RiskLevel, ToolContract, ToolConstraints, ToolResult
+
+
+class WebSearchTool:
+    """Mock web search returning deterministic results."""
+
+    def __init__(self) -> None:
+        self.contract = ToolContract(
+            name="web_search",
+            description="Search the web (mocked results).",
+            version="1.0.0",
+            risk=RiskLevel.READ,
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "top_k": {"type": "integer", "minimum": 1, "maximum": 10},
+                },
+                "required": ["query"],
+            },
+            output_schema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "title": {"type": "string"},
+                                "url": {"type": "string"},
+                                "snippet": {"type": "string"},
+                            },
+                            "required": ["title", "url", "snippet"],
+                        },
+                    },
+                },
+                "required": ["query", "results"],
+            },
+            constraints=ToolConstraints(requires_network=True),
+            metadata={"category": "web"},
+        )
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        query = str(kwargs.get("query", "")).strip()
+        top_k = int(kwargs.get("top_k") or 5)
+
+        results = [
+            {
+                "title": f"Result {idx + 1} for '{query}'",
+                "url": f"https://example.com/search/{idx + 1}",
+                "snippet": f"Mock snippet for '{query}' (item {idx + 1}).",
+            }
+            for idx in range(top_k)
+        ]
+
+        return ToolResult(
+            status=ExecutionStatus.SUCCESS,
+            output={"query": query, "results": results},
+            metadata={"tool_version": self.contract.version},
+        )
+
+
+__all__ = ["WebSearchTool"]

--- a/src/agent_core/tools/contract.py
+++ b/src/agent_core/tools/contract.py
@@ -1,0 +1,239 @@
+"""Tool contracts and execution results for agent_core."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Any, Mapping, Sequence
+from uuid import uuid4
+
+
+class ExecutionStatus(StrEnum):
+    SUCCESS = "success"
+    FAILURE = "failure"
+    TIMEOUT = "timeout"
+    INVALID_INPUT = "invalid_input"
+    NOT_FOUND = "not_found"
+
+
+class RiskLevel(StrEnum):
+    READ = "read"
+    WRITE = "write"
+    ADMIN = "admin"
+
+
+@dataclass
+class ToolIdempotency:
+    required: bool = False
+    key_field: str | None = None
+
+
+@dataclass
+class ToolDataHandling:
+    pii: bool = False
+    secrets: bool = False
+
+
+@dataclass
+class ToolConstraints:
+    requires_network: bool = False
+    requires_file_access: bool = False
+    requires_write: bool = False
+    max_runtime_ms: int = 0
+
+
+@dataclass
+class ToolPermissions:
+    read_paths: list[str] = field(default_factory=list)
+    write_paths: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ToolContract:
+    name: str
+    description: str
+    version: str = "1.0.0"
+    risk: RiskLevel | str = RiskLevel.READ
+    input_schema: Mapping[str, Any] = field(default_factory=dict)
+    output_schema: Mapping[str, Any] | None = None
+    required_scopes: list[str] = field(default_factory=list)
+    idempotency: ToolIdempotency = field(default_factory=ToolIdempotency)
+    data_handling: ToolDataHandling = field(default_factory=ToolDataHandling)
+    constraints: ToolConstraints = field(default_factory=ToolConstraints)
+    permissions: ToolPermissions = field(default_factory=ToolPermissions)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("ToolContract.name must be set.")
+        if not self.description:
+            raise ValueError("ToolContract.description must be set.")
+        if isinstance(self.risk, str):
+            self.risk = RiskLevel(self.risk)
+        if self.risk in {RiskLevel.WRITE, RiskLevel.ADMIN} and not self.idempotency.required:
+            raise ValueError("Write/admin tools must declare idempotency.required=True.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "version": self.version,
+            "risk": self.risk.value if isinstance(self.risk, RiskLevel) else str(self.risk),
+            "input_schema": dict(self.input_schema),
+            "output_schema": dict(self.output_schema) if self.output_schema is not None else None,
+            "required_scopes": list(self.required_scopes),
+            "idempotency": {
+                "required": self.idempotency.required,
+                "key_field": self.idempotency.key_field,
+            },
+            "data_handling": {
+                "pii": self.data_handling.pii,
+                "secrets": self.data_handling.secrets,
+            },
+            "constraints": {
+                "requires_network": self.constraints.requires_network,
+                "requires_file_access": self.constraints.requires_file_access,
+                "requires_write": self.constraints.requires_write,
+                "max_runtime_ms": self.constraints.max_runtime_ms,
+            },
+            "permissions": {
+                "read_paths": list(self.permissions.read_paths),
+                "write_paths": list(self.permissions.write_paths),
+            },
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ToolContract":
+        idempotency_payload = payload.get("idempotency") or {}
+        data_handling_payload = payload.get("data_handling") or {}
+        constraints_payload = payload.get("constraints") or {}
+        permissions_payload = payload.get("permissions") or {}
+        return cls(
+            name=str(payload.get("name", "")).strip(),
+            description=str(payload.get("description", "")).strip(),
+            version=str(payload.get("version", "1.0.0")).strip() or "1.0.0",
+            risk=payload.get("risk", RiskLevel.READ),
+            input_schema=payload.get("input_schema") or {},
+            output_schema=payload.get("output_schema"),
+            required_scopes=list(payload.get("required_scopes") or []),
+            idempotency=ToolIdempotency(
+                required=bool(idempotency_payload.get("required", False)),
+                key_field=idempotency_payload.get("key_field"),
+            ),
+            data_handling=ToolDataHandling(
+                pii=bool(data_handling_payload.get("pii", False)),
+                secrets=bool(data_handling_payload.get("secrets", False)),
+            ),
+            constraints=ToolConstraints(
+                requires_network=bool(constraints_payload.get("requires_network", False)),
+                requires_file_access=bool(constraints_payload.get("requires_file_access", False)),
+                requires_write=bool(constraints_payload.get("requires_write", False)),
+                max_runtime_ms=int(constraints_payload.get("max_runtime_ms", 0) or 0),
+            ),
+            permissions=ToolPermissions(
+                read_paths=list(permissions_payload.get("read_paths") or []),
+                write_paths=list(permissions_payload.get("write_paths") or []),
+            ),
+            metadata=dict(payload.get("metadata") or {}),
+        )
+
+
+@dataclass
+class TraceContext:
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
+        }
+
+
+@dataclass
+class ToolCall:
+    tool_name: str
+    arguments: Mapping[str, Any]
+    tool_call_id: str = field(default_factory=lambda: uuid4().hex)
+    run_id: str | None = None
+    timeout_ms: int | None = None
+    trace: TraceContext | None = None
+    scopes: Sequence[str] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_name": self.tool_name,
+            "arguments": dict(self.arguments),
+            "tool_call_id": self.tool_call_id,
+            "run_id": self.run_id,
+            "timeout_ms": self.timeout_ms,
+            "trace": self.trace.to_dict() if self.trace else None,
+            "scopes": list(self.scopes) if self.scopes is not None else None,
+        }
+
+
+@dataclass
+class ToolError:
+    type: str
+    message: str
+    details: dict[str, Any] | None = None
+    retryable: bool = False
+    source: str = "tool"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.type,
+            "message": self.message,
+            "details": dict(self.details) if self.details else None,
+            "retryable": self.retryable,
+            "source": self.source,
+        }
+
+
+@dataclass
+class ToolResult:
+    status: ExecutionStatus
+    output: Any = None
+    error: ToolError | None = None
+    duration_ms: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+    tool_call_id: str | None = None
+    tool_name: str | None = None
+    trace: TraceContext | None = None
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    @property
+    def success(self) -> bool:
+        return self.status == ExecutionStatus.SUCCESS
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "output": self.output,
+            "error": self.error.to_dict() if self.error else None,
+            "duration_ms": self.duration_ms,
+            "metadata": dict(self.metadata),
+            "tool_call_id": self.tool_call_id,
+            "tool_name": self.tool_name,
+            "trace": self.trace.to_dict() if self.trace else None,
+            "timestamp": self.timestamp,
+        }
+
+
+__all__ = [
+    "ExecutionStatus",
+    "RiskLevel",
+    "ToolCall",
+    "ToolConstraints",
+    "ToolContract",
+    "ToolDataHandling",
+    "ToolError",
+    "ToolIdempotency",
+    "ToolPermissions",
+    "ToolResult",
+    "TraceContext",
+]

--- a/src/agent_core/tools/exceptions.py
+++ b/src/agent_core/tools/exceptions.py
@@ -1,0 +1,53 @@
+"""Tool execution error types."""
+
+from __future__ import annotations
+
+
+class ToolExecutionError(RuntimeError):
+    """Base class for tool execution errors."""
+
+    error_type = "ToolError"
+
+    def __init__(self, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+
+
+class ToolNotFound(ToolExecutionError):
+    error_type = "ToolNotFound"
+
+
+class ToolTimeout(ToolExecutionError):
+    error_type = "ToolTimeout"
+
+
+class ToolProviderError(ToolExecutionError):
+    error_type = "ToolProviderError"
+
+
+class ToolResultInvalid(ToolExecutionError):
+    error_type = "ToolResultInvalid"
+
+
+class ToolInputInvalid(ToolExecutionError):
+    error_type = "ToolInputInvalid"
+
+
+class PolicyViolation(ToolExecutionError):
+    error_type = "PolicyViolation"
+
+
+class BudgetExceeded(ToolExecutionError):
+    error_type = "BudgetExceeded"
+
+
+__all__ = [
+    "BudgetExceeded",
+    "PolicyViolation",
+    "ToolExecutionError",
+    "ToolInputInvalid",
+    "ToolNotFound",
+    "ToolProviderError",
+    "ToolResultInvalid",
+    "ToolTimeout",
+]

--- a/src/agent_core/tools/executor.py
+++ b/src/agent_core/tools/executor.py
@@ -1,0 +1,319 @@
+"""ToolExecutor: central enforcement point for tool calls."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from jsonschema import ValidationError, validate
+
+from ..config.models import ObservabilityConfig, PoliciesConfig
+from .contract import ExecutionStatus, ToolCall, ToolContract, ToolError, ToolResult
+from .exceptions import (
+    BudgetExceeded,
+    PolicyViolation,
+    ToolInputInvalid,
+    ToolNotFound,
+    ToolProviderError,
+    ToolResultInvalid,
+    ToolTimeout,
+)
+from .provider import ToolProvider
+
+
+EventEmitter = Callable[[Mapping[str, Any]], None]
+
+
+class ToolExecutor:
+    """Validate, enforce policy, execute, and audit tool calls."""
+
+    def __init__(
+        self,
+        providers: Sequence[ToolProvider],
+        allowlist: Sequence[str] | None = None,
+        policies: PoliciesConfig | None = None,
+        observability: ObservabilityConfig | None = None,
+        emit_event: EventEmitter | None = None,
+    ) -> None:
+        self._providers = list(providers)
+        self._allowlist = set(allowlist or [])
+        self._policies = policies or PoliciesConfig()
+        self._observability = observability or ObservabilityConfig()
+        self._emit_event = emit_event
+        self._tool_index: dict[str, tuple[ToolProvider, ToolContract]] = {}
+        self._call_counts: dict[str, int] = defaultdict(int)
+
+    async def execute(self, call: ToolCall) -> ToolResult:
+        tool_name = call.tool_name
+
+        if not self._allowlist or tool_name not in self._allowlist:
+            return self._blocked(
+                call,
+                PolicyViolation("Tool not allowlisted."),
+            )
+
+        budget_key = call.run_id or "default"
+        max_calls = self._policies.budgets.max_tool_calls
+        if max_calls and self._call_counts[budget_key] >= max_calls:
+            return self._blocked(call, BudgetExceeded("Tool call budget exceeded."))
+
+        provider, contract = await self._resolve_tool(tool_name)
+        if provider is None or contract is None:
+            return self._error_result(call, ToolNotFound(f"Tool '{tool_name}' not found."))
+
+        if self._policies.read_only and (
+            contract.risk.value in {"write", "admin"} or contract.constraints.requires_write
+        ):
+            return self._blocked(call, PolicyViolation("Tool blocked in read-only mode."))
+
+        if contract.required_scopes:
+            scopes = set(call.scopes or [])
+            if not set(contract.required_scopes).issubset(scopes):
+                return self._blocked(call, PolicyViolation("Missing required scopes."))
+
+        try:
+            self._validate_paths(contract, call.arguments)
+        except PolicyViolation as exc:
+            return self._blocked(call, exc)
+
+        try:
+            self._validate_schema(contract.input_schema, call.arguments, ToolInputInvalid)
+        except ToolInputInvalid as exc:
+            return self._error_result(call, exc, status=ExecutionStatus.INVALID_INPUT)
+
+        self._call_counts[budget_key] += 1
+        self._emit("tool.call.started", call, contract, status=ExecutionStatus.SUCCESS)
+
+        timeout_s = self._timeout_seconds(call, contract)
+        start = time.perf_counter()
+        try:
+            if timeout_s:
+                result = await asyncio.wait_for(
+                    provider.execute(tool_name, call.arguments),
+                    timeout=timeout_s,
+                )
+            else:
+                result = await provider.execute(tool_name, call.arguments)
+        except asyncio.TimeoutError as exc:
+            return self._error_result(call, ToolTimeout(str(exc)), status=ExecutionStatus.TIMEOUT)
+        except ToolNotFound as exc:
+            return self._error_result(call, exc, status=ExecutionStatus.NOT_FOUND)
+        except ToolProviderError as exc:
+            return self._error_result(call, exc)
+        except Exception as exc:  # pragma: no cover - covered by provider tests
+            return self._error_result(call, ToolProviderError(str(exc)))
+
+        duration_ms = (time.perf_counter() - start) * 1000.0
+        if not isinstance(result, ToolResult):
+            result = ToolResult(status=ExecutionStatus.SUCCESS, output=result)
+        normalized = self._normalize_result(call, contract, result, duration_ms)
+
+        if normalized.status == ExecutionStatus.SUCCESS and contract.output_schema:
+            try:
+                self._validate_schema(contract.output_schema, normalized.output, ToolResultInvalid)
+            except ToolResultInvalid as exc:
+                normalized = self._error_result(call, exc, status=ExecutionStatus.FAILURE)
+
+        self._emit(
+            "tool.call.finished",
+            call,
+            contract,
+            status=normalized.status,
+            result=normalized,
+        )
+        return normalized
+
+    async def execute_batch(self, calls: Sequence[ToolCall]) -> list[ToolResult]:
+        results: list[ToolResult] = []
+        for call in calls:
+            results.append(await self.execute(call))
+        return results
+
+    async def _resolve_tool(
+        self,
+        tool_name: str,
+    ) -> tuple[ToolProvider | None, ToolContract | None]:
+        if tool_name in self._tool_index:
+            return self._tool_index[tool_name][0], self._tool_index[tool_name][1]
+
+        for provider in self._providers:
+            contracts = await provider.list_tools()
+            for contract in contracts:
+                if contract.name not in self._tool_index:
+                    self._tool_index[contract.name] = (provider, contract)
+
+        entry = self._tool_index.get(tool_name)
+        if entry is None:
+            if not self._providers:
+                return (None, None)
+            return self._providers[0], None
+        return entry
+
+    def _timeout_seconds(self, call: ToolCall, contract: ToolContract) -> float | None:
+        timeouts: list[float] = []
+        if call.timeout_ms:
+            timeouts.append(call.timeout_ms / 1000.0)
+        if contract.constraints.max_runtime_ms:
+            timeouts.append(contract.constraints.max_runtime_ms / 1000.0)
+        if not timeouts:
+            return None
+        return min(timeouts)
+
+    def _validate_schema(
+        self,
+        schema: Mapping[str, Any],
+        payload: Any,
+        error_cls: type[Exception],
+    ) -> None:
+        if not schema:
+            return
+        try:
+            validate(instance=payload, schema=schema)
+        except ValidationError as exc:
+            raise error_cls(str(exc)) from exc
+
+    def _validate_paths(self, contract: ToolContract, args: Mapping[str, Any]) -> None:
+        if not contract.constraints.requires_file_access and not contract.permissions.read_paths:
+            return
+        allowed = [Path(path).resolve() for path in contract.permissions.read_paths]
+        if not allowed:
+            return
+        raw_path = args.get("path")
+        if raw_path is None:
+            return
+        candidate = Path(str(raw_path)).resolve()
+        if not any(self._is_relative_to(candidate, root) for root in allowed):
+            raise PolicyViolation("Path not permitted by tool contract.")
+
+    @staticmethod
+    def _is_relative_to(path: Path, root: Path) -> bool:
+        try:
+            path.relative_to(root)
+            return True
+        except ValueError:
+            return False
+
+    def _normalize_result(
+        self,
+        call: ToolCall,
+        contract: ToolContract,
+        result: ToolResult,
+        duration_ms: float,
+    ) -> ToolResult:
+        merged = ToolResult(
+            status=result.status,
+            output=result.output,
+            error=result.error,
+            duration_ms=duration_ms,
+            metadata={**result.metadata, "tool_version": contract.version},
+            tool_call_id=call.tool_call_id,
+            tool_name=contract.name,
+            trace=call.trace,
+            timestamp=result.timestamp,
+        )
+        return merged
+
+    def _error_result(
+        self,
+        call: ToolCall,
+        exc: Exception,
+        *,
+        status: ExecutionStatus = ExecutionStatus.FAILURE,
+    ) -> ToolResult:
+        error = ToolError(
+            type=getattr(exc, "error_type", exc.__class__.__name__),
+            message=str(exc),
+            retryable=getattr(exc, "retryable", False),
+            source="policy" if isinstance(exc, (PolicyViolation, BudgetExceeded)) else "tool",
+        )
+        result = ToolResult(
+            status=status,
+            error=error,
+            duration_ms=0.0,
+            tool_call_id=call.tool_call_id,
+            tool_name=call.tool_name,
+            trace=call.trace,
+        )
+        self._emit(
+            "tool.call.finished",
+            call,
+            None,
+            status=status,
+            result=result,
+        )
+        return result
+
+    def _blocked(self, call: ToolCall, exc: Exception) -> ToolResult:
+        error = ToolError(
+            type=getattr(exc, "error_type", exc.__class__.__name__),
+            message=str(exc),
+            retryable=getattr(exc, "retryable", False),
+            source="policy",
+        )
+        result = ToolResult(
+            status=ExecutionStatus.FAILURE,
+            error=error,
+            duration_ms=0.0,
+            tool_call_id=call.tool_call_id,
+            tool_name=call.tool_name,
+            trace=call.trace,
+        )
+        self._emit(
+            "tool.call.blocked",
+            call,
+            None,
+            status=ExecutionStatus.FAILURE,
+            result=result,
+        )
+        return result
+
+    def _emit(
+        self,
+        event_type: str,
+        call: ToolCall,
+        contract: ToolContract | None,
+        *,
+        status: ExecutionStatus,
+        result: ToolResult | None = None,
+    ) -> None:
+        if self._emit_event is None:
+            return
+        redact = self._observability.redact
+        attrs: dict[str, Any] = {
+            "tool_name": call.tool_name,
+            "tool_call_id": call.tool_call_id,
+            "status": status.value,
+        }
+        if call.run_id:
+            attrs["run_id"] = call.run_id
+        if contract and (
+            (redact.pii and contract.data_handling.pii)
+            or (redact.secrets and contract.data_handling.secrets)
+        ):
+            attrs["arguments"] = "<redacted>"
+            if result is not None:
+                attrs["output"] = "<redacted>"
+        else:
+            attrs["arguments"] = dict(call.arguments)
+            if result is not None:
+                attrs["output"] = result.output
+
+        if result and result.error:
+            attrs["error"] = result.error.to_dict()
+
+        payload = {
+            "time": datetime.now(timezone.utc).isoformat(),
+            "event_type": event_type,
+            "severity": "warn" if result and result.error else "info",
+            "actor": "tool",
+            "trace": call.trace.to_dict() if call.trace else None,
+            "attrs": attrs,
+        }
+        self._emit_event(payload)
+
+
+__all__ = ["ToolExecutor"]

--- a/src/agent_core/tools/fixture.py
+++ b/src/agent_core/tools/fixture.py
@@ -1,0 +1,50 @@
+"""Fixture-based tool provider adapter."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from ..providers import FixtureToolProvider, ToolFixture
+from .contract import ExecutionStatus, ToolContract, ToolResult
+from .exceptions import ToolNotFound
+from .provider import ToolProvider
+
+
+class FixtureToolProviderAdapter(ToolProvider):
+    """Adapter to expose FixtureToolProvider as a ToolProvider."""
+
+    def __init__(self, path: str) -> None:
+        self._provider = FixtureToolProvider(path)
+        self._contracts = self._build_contracts(self._provider)
+
+    async def list_tools(self) -> Sequence[ToolContract]:
+        return list(self._contracts.values())
+
+    async def execute(self, tool_name: str, args: Mapping[str, Any]) -> ToolResult:
+        contract = self._contracts.get(tool_name)
+        if contract is None:
+            raise ToolNotFound(f"Tool '{tool_name}' not available in fixtures.")
+        output = await self._provider.execute(tool_name, args, tool_version=contract.version)
+        return ToolResult(
+            status=ExecutionStatus.SUCCESS,
+            output=output,
+            metadata={"tool_version": contract.version, "fixture": True},
+        )
+
+    @staticmethod
+    def _build_contracts(provider: FixtureToolProvider) -> dict[str, ToolContract]:
+        contracts: dict[str, ToolContract] = {}
+        for fixture in provider.list_fixtures():
+            if fixture.tool_name in contracts:
+                continue
+            contracts[fixture.tool_name] = ToolContract(
+                name=fixture.tool_name,
+                description=f"Fixture tool for {fixture.tool_name}.",
+                version=fixture.tool_version or "1.0.0",
+                input_schema={"type": "object"},
+                output_schema={"type": "object"},
+            )
+        return contracts
+
+
+__all__ = ["FixtureToolProviderAdapter"]

--- a/src/agent_core/tools/mcp.py
+++ b/src/agent_core/tools/mcp.py
@@ -1,0 +1,96 @@
+"""Basic MCP tool provider stub."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, Sequence
+
+import httpx
+
+from .contract import ExecutionStatus, ToolContract, ToolResult
+from .exceptions import ToolProviderError
+from .provider import ToolProvider
+
+
+class McpToolProvider(ToolProvider):
+    """HTTP-based MCP tool provider (basic)."""
+
+    def __init__(
+        self,
+        base_url: str,
+        timeout_s: float | None = 30.0,
+        bearer_token_env: str | None = None,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout_s = timeout_s
+        self._bearer_token_env = bearer_token_env
+        self._client = client or httpx.AsyncClient(timeout=self._timeout_s)
+        self._tool_cache: dict[str, ToolContract] = {}
+
+    def _headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self._bearer_token_env:
+            token = os.getenv(self._bearer_token_env, "").strip()
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    async def list_tools(self) -> Sequence[ToolContract]:
+        if self._tool_cache:
+            return list(self._tool_cache.values())
+        try:
+            response = await self._client.get(
+                f"{self._base_url}/tools",
+                headers=self._headers(),
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:  # pragma: no cover - exercised via executor error mapping
+            raise ToolProviderError(f"MCP list_tools failed: {exc}") from exc
+
+        tools_payload = payload.get("tools") if isinstance(payload, dict) else payload
+        if not isinstance(tools_payload, list):
+            raise ToolProviderError("MCP list_tools returned invalid payload.")
+
+        for tool_payload in tools_payload:
+            contract = ToolContract.from_dict(tool_payload)
+            self._tool_cache[contract.name] = contract
+        return list(self._tool_cache.values())
+
+    async def execute(self, tool_name: str, args: Mapping[str, Any]) -> ToolResult:
+        payload = {"tool_name": tool_name, "arguments": dict(args)}
+        try:
+            response = await self._client.post(
+                f"{self._base_url}/execute",
+                json=payload,
+                headers=self._headers(),
+            )
+            response.raise_for_status()
+            data = response.json()
+        except Exception as exc:  # pragma: no cover - exercised via executor error mapping
+            raise ToolProviderError(f"MCP execute failed: {exc}") from exc
+
+        if isinstance(data, dict) and "status" in data:
+            status_raw = str(data.get("status", ExecutionStatus.SUCCESS.value))
+            try:
+                status = ExecutionStatus(status_raw)
+            except ValueError:
+                status = ExecutionStatus.FAILURE
+            return ToolResult(
+                status=status,
+                output=data.get("output"),
+                metadata={"provider": "mcp"},
+            )
+
+        return ToolResult(
+            status=ExecutionStatus.SUCCESS,
+            output=data,
+            metadata={"provider": "mcp"},
+        )
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
+__all__ = ["McpToolProvider"]

--- a/src/agent_core/tools/native.py
+++ b/src/agent_core/tools/native.py
@@ -1,0 +1,38 @@
+"""Native tool provider for built-in tools."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from .builtin import CalculatorTool, FileReadTool, WebSearchTool
+from .contract import ToolContract, ToolResult
+from .exceptions import ToolNotFound
+from .provider import Tool, ToolProvider
+
+
+class NativeToolProvider(ToolProvider):
+    """Provide access to in-process built-in tools."""
+
+    def __init__(self, tools: Mapping[str, Tool] | None = None) -> None:
+        if tools is None:
+            tools = {
+                "calculator": CalculatorTool(),
+                "web_search": WebSearchTool(),
+                "file_read": FileReadTool(),
+            }
+        self._tools = dict(tools)
+
+    async def list_tools(self) -> Sequence[ToolContract]:
+        return [tool.contract for tool in self._tools.values()]
+
+    async def execute(self, tool_name: str, args: Mapping[str, Any]) -> ToolResult:
+        tool = self._tools.get(tool_name)
+        if tool is None:
+            raise ToolNotFound(f"Tool '{tool_name}' not found in native provider.")
+        return await tool.execute(**dict(args))
+
+    def get_tool(self, tool_name: str) -> Tool | None:
+        return self._tools.get(tool_name)
+
+
+__all__ = ["NativeToolProvider"]

--- a/src/agent_core/tools/provider.py
+++ b/src/agent_core/tools/provider.py
@@ -1,0 +1,27 @@
+"""Tool provider interfaces for agent_core."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
+
+from .contract import ToolContract, ToolResult
+
+
+@runtime_checkable
+class Tool(Protocol):
+    contract: ToolContract
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        ...
+
+
+@runtime_checkable
+class ToolProvider(Protocol):
+    async def list_tools(self) -> Sequence[ToolContract]:
+        ...
+
+    async def execute(self, tool_name: str, args: Mapping[str, Any]) -> ToolResult:
+        ...
+
+
+__all__ = ["Tool", "ToolProvider"]

--- a/tests/integration/test_mcp_provider.py
+++ b/tests/integration/test_mcp_provider.py
@@ -1,0 +1,53 @@
+"""Integration tests for MCP tool provider (mocked transport)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from agent_core.tools import ExecutionStatus, McpToolProvider
+
+
+@pytest.mark.asyncio
+async def test_mcp_provider_list_and_execute() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/tools":
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "name": "calculator",
+                        "description": "mock calculator",
+                        "version": "1.0.0",
+                        "risk": "read",
+                        "input_schema": {"type": "object"},
+                        "output_schema": {"type": "object"},
+                    }
+                ],
+            )
+        if request.url.path == "/execute":
+            payload = json.loads(request.content.decode("utf-8"))
+            return httpx.Response(
+                200,
+                json={
+                    "status": "success",
+                    "output": {"echo": payload["arguments"]},
+                },
+            )
+        return httpx.Response(404, json={"error": "not found"})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url="http://mcp.test")
+
+    provider = McpToolProvider(base_url="http://mcp.test", client=client)
+    tools = await provider.list_tools()
+
+    assert tools[0].name == "calculator"
+
+    result = await provider.execute("calculator", {"a": 1})
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.output == {"echo": {"a": 1}}
+
+    await provider.aclose()

--- a/tests/unit/agent_core/test_engine_factory.py
+++ b/tests/unit/agent_core/test_engine_factory.py
@@ -1,0 +1,26 @@
+"""Tests for EngineFactory build_with_config."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_core.config.models import AgentCoreConfig, EngineConfig, ToolsConfig
+from agent_core.factories import EngineFactory, ToolExecutorFactory
+from agent_core.registry import get_global_registry
+
+
+@pytest.mark.asyncio
+async def test_engine_factory_wires_tool_executor() -> None:
+    registry = get_global_registry()
+    config = AgentCoreConfig(
+        engine=EngineConfig(key="local"),
+        tools=ToolsConfig(allowlist=["calculator"]),
+    )
+
+    engine_factory = EngineFactory(registry.engines)
+    tool_factory = ToolExecutorFactory(registry.tool_providers)
+
+    engine = engine_factory.build_with_config(config, tool_executor_factory=tool_factory)
+
+    assert hasattr(engine, "tool_executor")
+    assert engine.tool_executor is not None

--- a/tests/unit/agent_core/test_native_tools.py
+++ b/tests/unit/agent_core/test_native_tools.py
@@ -1,0 +1,48 @@
+"""Tests for native built-in tools."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_core.tools import ExecutionStatus
+from agent_core.tools.builtin import CalculatorTool, FileReadTool, WebSearchTool
+from agent_core.tools.native import NativeToolProvider
+
+
+@pytest.mark.asyncio
+async def test_native_provider_lists_tools() -> None:
+    provider = NativeToolProvider()
+    contracts = await provider.list_tools()
+    names = {contract.name for contract in contracts}
+
+    assert {"calculator", "web_search", "file_read"} <= names
+
+
+@pytest.mark.asyncio
+async def test_calculator_tool_executes() -> None:
+    tool = CalculatorTool()
+    result = await tool.execute(operation="add", a=2, b=3)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.output == {"value": 5}
+
+
+@pytest.mark.asyncio
+async def test_web_search_tool_executes() -> None:
+    tool = WebSearchTool()
+    result = await tool.execute(query="agents", top_k=2)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert len(result.output["results"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_file_read_tool_executes(tmp_path) -> None:
+    path = tmp_path / "sample.txt"
+    path.write_text("line1\nline2\nline3", encoding="utf-8")
+
+    tool = FileReadTool(max_lines=5)
+    result = await tool.execute(path=str(path), start_line=1, end_line=2)
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert "line1" in result.output["content"]

--- a/tests/unit/agent_core/test_tool_contract.py
+++ b/tests/unit/agent_core/test_tool_contract.py
@@ -1,0 +1,28 @@
+"""Tests for tool contract definitions."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_core.tools import RiskLevel, ToolContract, ToolIdempotency
+
+
+def test_tool_contract_requires_idempotency_for_write() -> None:
+    with pytest.raises(ValueError, match="idempotency"):
+        ToolContract(
+            name="write_tool",
+            description="Writes data.",
+            risk=RiskLevel.WRITE,
+        )
+
+
+def test_tool_contract_accepts_idempotent_write() -> None:
+    contract = ToolContract(
+        name="write_tool",
+        description="Writes data.",
+        risk=RiskLevel.WRITE,
+        idempotency=ToolIdempotency(required=True, key_field="request_id"),
+    )
+
+    assert contract.idempotency.required
+    assert contract.idempotency.key_field == "request_id"

--- a/tests/unit/agent_core/test_tool_executor.py
+++ b/tests/unit/agent_core/test_tool_executor.py
@@ -1,0 +1,188 @@
+"""Tests for ToolExecutor policy enforcement."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agent_core.config.models import BudgetsConfig, PoliciesConfig
+from agent_core.tools import (
+    ExecutionStatus,
+    RiskLevel,
+    ToolCall,
+    ToolContract,
+    ToolExecutor,
+    ToolIdempotency,
+    ToolPermissions,
+    ToolResult,
+)
+from agent_core.tools.provider import ToolProvider
+
+
+class DummyTool:
+    def __init__(self, contract: ToolContract, result: ToolResult | None = None, delay: float = 0.0):
+        self.contract = contract
+        self._result = result
+        self._delay = delay
+
+    async def execute(self, **kwargs):  # type: ignore[override]
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        if self._result is not None:
+            return self._result
+        return ToolResult(status=ExecutionStatus.SUCCESS, output={"ok": True})
+
+
+class DummyProvider(ToolProvider):
+    def __init__(self, tools: dict[str, DummyTool]) -> None:
+        self._tools = tools
+
+    async def list_tools(self):
+        return [tool.contract for tool in self._tools.values()]
+
+    async def execute(self, tool_name: str, args):
+        return await self._tools[tool_name].execute(**args)
+
+
+@pytest.mark.asyncio
+async def test_allowlist_blocks_tool() -> None:
+    contract = ToolContract(name="calculator", description="calc")
+    provider = DummyProvider({"calculator": DummyTool(contract)})
+    executor = ToolExecutor([provider], allowlist=["calculator"])
+
+    call = ToolCall(tool_name="other_tool", arguments={})
+    result = await executor.execute(call)
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.error is not None
+    assert result.error.type == "PolicyViolation"
+
+
+@pytest.mark.asyncio
+async def test_input_validation_fails() -> None:
+    contract = ToolContract(
+        name="calculator",
+        description="calc",
+        input_schema={
+            "type": "object",
+            "properties": {"a": {"type": "number"}},
+            "required": ["a"],
+        },
+    )
+    provider = DummyProvider({"calculator": DummyTool(contract)})
+    executor = ToolExecutor([provider], allowlist=["calculator"])
+
+    call = ToolCall(tool_name="calculator", arguments={})
+    result = await executor.execute(call)
+
+    assert result.status == ExecutionStatus.INVALID_INPUT
+
+
+@pytest.mark.asyncio
+async def test_read_only_blocks_write_tool() -> None:
+    contract = ToolContract(
+        name="write_tool",
+        description="write",
+        risk=RiskLevel.WRITE,
+        idempotency=ToolIdempotency(required=True),
+    )
+    provider = DummyProvider({"write_tool": DummyTool(contract)})
+    policies = PoliciesConfig(read_only=True)
+    executor = ToolExecutor([provider], allowlist=["write_tool"], policies=policies)
+
+    call = ToolCall(tool_name="write_tool", arguments={})
+    result = await executor.execute(call)
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.error is not None
+    assert result.error.type == "PolicyViolation"
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_enforced() -> None:
+    contract = ToolContract(name="slow_tool", description="slow")
+    provider = DummyProvider({"slow_tool": DummyTool(contract, delay=0.05)})
+    executor = ToolExecutor([provider], allowlist=["slow_tool"])
+
+    call = ToolCall(tool_name="slow_tool", arguments={}, timeout_ms=1)
+    result = await executor.execute(call)
+
+    assert result.status == ExecutionStatus.TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_output_schema_validation() -> None:
+    contract = ToolContract(
+        name="tool",
+        description="output test",
+        output_schema={
+            "type": "object",
+            "properties": {"value": {"type": "number"}},
+            "required": ["value"],
+        },
+    )
+    bad_result = ToolResult(status=ExecutionStatus.SUCCESS, output={"nope": 1})
+    provider = DummyProvider({"tool": DummyTool(contract, result=bad_result)})
+    executor = ToolExecutor([provider], allowlist=["tool"])
+
+    call = ToolCall(tool_name="tool", arguments={})
+    result = await executor.execute(call)
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.error is not None
+    assert result.error.type == "ToolResultInvalid"
+
+
+@pytest.mark.asyncio
+async def test_budget_enforced_per_run() -> None:
+    contract = ToolContract(name="tool", description="budget")
+    provider = DummyProvider({"tool": DummyTool(contract)})
+    policies = PoliciesConfig(budgets=BudgetsConfig(max_tool_calls=1))
+    executor = ToolExecutor([provider], allowlist=["tool"], policies=policies)
+
+    call = ToolCall(tool_name="tool", arguments={}, run_id="run-1")
+    first = await executor.execute(call)
+    second = await executor.execute(call)
+
+    assert first.status == ExecutionStatus.SUCCESS
+    assert second.status == ExecutionStatus.FAILURE
+    assert second.error is not None
+    assert second.error.type == "BudgetExceeded"
+
+
+@pytest.mark.asyncio
+async def test_scopes_required() -> None:
+    contract = ToolContract(
+        name="scoped_tool",
+        description="scoped",
+        required_scopes=["scope:read"],
+    )
+    provider = DummyProvider({"scoped_tool": DummyTool(contract)})
+    executor = ToolExecutor([provider], allowlist=["scoped_tool"])
+
+    call = ToolCall(tool_name="scoped_tool", arguments={}, scopes=["scope:write"])
+    result = await executor.execute(call)
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.error is not None
+    assert result.error.type == "PolicyViolation"
+
+
+@pytest.mark.asyncio
+async def test_read_path_enforced(tmp_path) -> None:
+    contract = ToolContract(
+        name="file_read",
+        description="file read",
+        permissions=ToolPermissions(read_paths=[str(tmp_path)]),
+    )
+    provider = DummyProvider({"file_read": DummyTool(contract)})
+    executor = ToolExecutor([provider], allowlist=["file_read"])
+
+    other_path = tmp_path.parent / "not_allowed.txt"
+    call = ToolCall(tool_name="file_read", arguments={"path": str(other_path)})
+    result = await executor.execute(call)
+
+    assert result.status == ExecutionStatus.FAILURE
+    assert result.error is not None
+    assert result.error.type == "PolicyViolation"

--- a/tests/unit/agent_core/test_tool_executor_factory.py
+++ b/tests/unit/agent_core/test_tool_executor_factory.py
@@ -1,0 +1,46 @@
+"""Tests for ToolExecutorFactory wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_core.config.models import AgentCoreConfig, ToolsConfig
+from agent_core.factories import ToolExecutorFactory
+from agent_core.registry import get_global_registry
+from agent_core.tools import ExecutionStatus, ToolCall
+
+
+@pytest.mark.asyncio
+async def test_factory_builds_with_native_provider() -> None:
+    registry = get_global_registry()
+    config = AgentCoreConfig(
+        tools=ToolsConfig(allowlist=["calculator"]),
+    )
+
+    factory = ToolExecutorFactory(registry.tool_providers)
+    executor = factory.build(config)
+
+    result = await executor.execute(
+        ToolCall(tool_name="calculator", arguments={"operation": "add", "a": 1, "b": 2})
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_factory_builds_with_fixture_provider() -> None:
+    registry = get_global_registry()
+    config = AgentCoreConfig(
+        tools=ToolsConfig(
+            allowlist=["calculator"],
+            providers={"fixture": {"path": "tests/fixtures/tool_fixtures.json"}},
+        ),
+    )
+
+    factory = ToolExecutorFactory(registry.tool_providers)
+    executor = factory.build(config)
+
+    result = await executor.execute(ToolCall(tool_name="calculator", arguments={"a": 2, "b": 2}))
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.output == {"value": 4}


### PR DESCRIPTION
﻿## Description

Implement Tool Executor & Contracts for Story #94 with centralized enforcement, native/MCP providers, and deterministic fixtures. Add ToolExecutor wiring into engine construction and document tool contracts usage.

Closes #94

## Changes

- Add ToolContract/ToolExecutor and provider implementations (native + MCP + fixture adapter)
- Wire ToolExecutorFactory into EngineFactory and add minimal LocalEngine
- Add unit/integration tests and tooling documentation

## Evidence Mapping

| Criterion | Test | Location | Status |
|-----------|------|----------|--------|
| ToolContract schema + idempotency enforcement | `pytest tests/unit/agent_core/test_tool_contract.py -q` | tests/unit/agent_core/test_tool_contract.py | ✅ |
| ToolExecutor validation/allowlist/read-only/timeout/output validation | `pytest tests/unit/agent_core/test_tool_executor.py -q` | tests/unit/agent_core/test_tool_executor.py | ✅ |
| Native tools + MCP provider stub | `pytest tests/unit/agent_core/test_native_tools.py tests/integration/test_mcp_provider.py -q` | tests/unit/agent_core/test_native_tools.py; tests/integration/test_mcp_provider.py | ✅ |
| ToolExecutorFactory + engine wiring | `pytest tests/unit/agent_core/test_tool_executor_factory.py tests/unit/agent_core/test_engine_factory.py -q` | tests/unit/agent_core/test_tool_executor_factory.py; tests/unit/agent_core/test_engine_factory.py | ✅ |

## Checklist

### Code Quality
- [x] All acceptance criteria met with evidence above
- [x] Tests added and passing
- [x] No regressions (existing tests pass)
- [x] Code follows project conventions
- [x] No debug statements or commented code

### Documentation
- [x] README updated (if applicable)
- [x] API docs updated (if applicable)
- [x] Code comments for complex logic

### Process
- [x] PR linked to story (`Closes #`)
- [x] Branch follows naming convention
- [x] Branch up to date with main
- [x] Self-reviewed the diff

## Screenshots (if UI change)

| Before | After |
|--------|-------|
| N/A | N/A |

## Notes for Reviewers

- Tests run: pytest tests/unit/agent_core tests/unit/test_fixture_tools.py tests/integration/test_mcp_provider.py -q
- New dependency: jsonschema (for tool input/output validation)

---

**For Reviewer:** Validate evidence mapping before approving.
**For CODEOWNER:** Run pre-merge checklist before merging.
