### PR TITLE
feat(story-97): AgentCore public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ core = AgentCore.from_file("agent_core.json")
 result = core.run_sync(RunRequest(input="Hello"))
 print(result.output_text)
 ```
+Note: `run_sync` raises if called inside an active event loop; use `await core.run(...)` in async contexts.
 
 Example (short-term session memory):
 ```python

--- a/README.md
+++ b/README.md
@@ -82,9 +82,19 @@ Labs are the hands-on companion to the knowledge base and curriculum:
 
 ## Agent Core Docs
 
+- AgentCore public API: `docs/agent_core_api.md`
 - Execution engines: `docs/engine.md`
 - Tool contracts and executor: `docs/tools.md`
 - Short-term memory: `docs/memory.md`
+
+Quick start (AgentCore):
+```python
+from agent_core import AgentCore, RunRequest
+
+core = AgentCore.from_file("agent_core.json")
+result = core.run_sync(RunRequest(input="Hello"))
+print(result.output_text)
+```
 
 Example (short-term session memory):
 ```python

--- a/docs/agent_core_api.md
+++ b/docs/agent_core_api.md
@@ -1,0 +1,30 @@
+# AgentCore Public API
+
+This document describes the primary entry point for `agent_core`.
+
+## Quick start
+
+```python
+from agent_core import AgentCore, RunRequest
+
+core = AgentCore.from_file("agent_core.json")
+result = core.run_sync(RunRequest(input="Summarize this document."))
+print(result.output_text)
+```
+
+## Constructors
+
+- `AgentCore.from_file(path)`: load YAML/JSON config and build AgentCore.
+- `AgentCore.from_env()`: load config from environment variables.
+- `AgentCore.from_config(config)`: use a pre-built `AgentCoreConfig`.
+
+## Execution methods
+
+- `await core.run(request) -> RunResult`
+- `await core.run_with_artifacts(request) -> (RunResult, RunArtifact)`
+- `core.run_sync(request) -> RunResult` (sync wrapper)
+
+## Notes
+
+- `run_sync` raises if called from an active event loop; use `await run()` in async contexts.
+- Tool calls flow through `ToolExecutor` and are governed by policies.

--- a/docs/agent_core_api.md
+++ b/docs/agent_core_api.md
@@ -24,6 +24,11 @@ print(result.output_text)
 - `await core.run_with_artifacts(request) -> (RunResult, RunArtifact)`
 - `core.run_sync(request) -> RunResult` (sync wrapper)
 
+## RunRequest + RunResult
+
+- `RunRequest`: input text, run_id, budgets (turns/time), metadata, cancellation event.
+- `RunResult`: status, output_text, turns, reason, metadata.
+
 ## Notes
 
 - `run_sync` raises if called from an active event loop; use `await run()` in async contexts.

--- a/src/agent_core/__init__.py
+++ b/src/agent_core/__init__.py
@@ -1,5 +1,6 @@
 """Production framework core package."""
 
+from .api import AgentCore, RunArtifact
 from .config import AgentCoreConfig, load_config
 from .exceptions import (
     ImplementationNotFoundError,
@@ -26,6 +27,7 @@ from .registry import (
 
 __all__ = [
     "AgentCoreConfig",
+    "AgentCore",
     "AgentCoreRegistry",
     "ENTRY_POINT_GROUP",
     "EngineComponents",
@@ -51,6 +53,7 @@ __all__ = [
     "Registry",
     "RegistryError",
     "RunRequest",
+    "RunArtifact",
     "RunResult",
     "RunStatus",
     "ToolProviderFactory",

--- a/src/agent_core/api.py
+++ b/src/agent_core/api.py
@@ -1,0 +1,133 @@
+"""Public API for agent_core."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
+
+from .config import AgentCoreConfig, load_config
+from .engine import EngineComponents, RunRequest, RunResult
+from .factories import EngineFactory, ModelFactory, ToolExecutorFactory
+from .memory import InMemorySessionStore, SessionStore
+from .registry import AgentCoreRegistry, get_global_registry
+from .tools import ToolExecutor
+
+
+@dataclass(frozen=True)
+class RunArtifact:
+    run_id: str
+    config_snapshot: dict[str, Any]
+    request: RunRequest
+    result: RunResult
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class AgentCore:
+    """Primary user entry point for agent_core."""
+
+    def __init__(
+        self,
+        config: AgentCoreConfig,
+        *,
+        registry: AgentCoreRegistry | None = None,
+        engine: Any | None = None,
+        models: Mapping[str, Any] | None = None,
+        tool_executor: ToolExecutor | None = None,
+        memory_factory: Callable[[], SessionStore] | None = None,
+        emit_event: Callable[[Mapping[str, Any]], None] | None = None,
+    ) -> None:
+        self.config = config
+        self.registry = registry or get_global_registry()
+        self._emit_event = emit_event
+
+        self._model_factory = ModelFactory(self.registry.model_providers)
+        self._tool_factory = ToolExecutorFactory(self.registry.tool_providers)
+        self._engine_factory = EngineFactory(self.registry.engines)
+
+        self._models = models or self._model_factory.build_role_map(config.models.roles)
+        self._tool_executor = tool_executor or self._tool_factory.build(config, emit_event=emit_event)
+        self._engine = engine or self._engine_factory.build_with_config(
+            config,
+            tool_executor_factory=_FixedToolExecutorFactory(self._tool_executor),
+            emit_event=emit_event,
+        )
+
+        self._memory_factory = memory_factory or self._default_memory_factory
+
+    @classmethod
+    def from_file(
+        cls,
+        path: str,
+        *,
+        registry: AgentCoreRegistry | None = None,
+        emit_event: Callable[[Mapping[str, Any]], None] | None = None,
+    ) -> "AgentCore":
+        config = load_config(path=path)
+        return cls(config, registry=registry, emit_event=emit_event)
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        registry: AgentCoreRegistry | None = None,
+        emit_event: Callable[[Mapping[str, Any]], None] | None = None,
+    ) -> "AgentCore":
+        config = load_config()
+        return cls(config, registry=registry, emit_event=emit_event)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: AgentCoreConfig,
+        *,
+        registry: AgentCoreRegistry | None = None,
+        emit_event: Callable[[Mapping[str, Any]], None] | None = None,
+    ) -> "AgentCore":
+        return cls(config, registry=registry, emit_event=emit_event)
+
+    async def run(self, request: RunRequest) -> RunResult:
+        components = EngineComponents(
+            models=self._models,
+            tool_executor=self._tool_executor,
+            memory=self._memory_factory(),
+            policies=self.config.policies,
+            emit_event=self._emit_event,
+        )
+        return await self._engine.execute(request, components)
+
+    async def run_with_artifacts(self, request: RunRequest) -> tuple[RunResult, RunArtifact]:
+        result = await self.run(request)
+        artifact = RunArtifact(
+            run_id=request.run_id,
+            config_snapshot=self.config.model_dump(),
+            request=request,
+            result=result,
+        )
+        return result, artifact
+
+    def run_sync(self, request: RunRequest) -> RunResult:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.run(request))
+        raise RuntimeError("run_sync cannot be called from a running event loop; use await run().")
+
+    @staticmethod
+    def _default_memory_factory() -> SessionStore:
+        return InMemorySessionStore()
+
+
+class _FixedToolExecutorFactory:
+    def __init__(self, tool_executor: ToolExecutor) -> None:
+        self._tool_executor = tool_executor
+
+    def build(
+        self,
+        config: AgentCoreConfig,
+        emit_event: Callable[[Mapping[str, Any]], None] | None = None,
+    ) -> ToolExecutor:
+        return self._tool_executor
+
+
+__all__ = ["AgentCore", "RunArtifact"]

--- a/tests/fixtures/agent_core_test_config.json
+++ b/tests/fixtures/agent_core_test_config.json
@@ -1,0 +1,21 @@
+{
+  "engine": {
+    "key": "local",
+    "config": {}
+  },
+  "models": {
+    "roles": {
+      "planner": {
+        "provider": "mock",
+        "model": "deterministic"
+      },
+      "actor": {
+        "provider": "mock",
+        "model": "deterministic"
+      }
+    }
+  },
+  "tools": {
+    "allowlist": []
+  }
+}

--- a/tests/integration/test_agent_core_e2e.py
+++ b/tests/integration/test_agent_core_e2e.py
@@ -1,0 +1,22 @@
+"""Integration tests for AgentCore public API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_core.api import AgentCore
+from agent_core.engine import RunRequest, RunStatus
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_agent_core_from_file_run_e2e() -> None:
+    config_path = Path("tests/fixtures/agent_core_test_config.json")
+    core = AgentCore.from_file(str(config_path))
+
+    result = await core.run(RunRequest(input="hello"))
+
+    assert result.status == RunStatus.SUCCESS
+    assert result.output_text

--- a/tests/unit/agent_core/test_agent_core.py
+++ b/tests/unit/agent_core/test_agent_core.py
@@ -1,0 +1,134 @@
+"""Unit tests for AgentCore public API."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_core import AgentCoreConfig
+from agent_core.api import AgentCore, RunArtifact
+from agent_core.config.models import EngineConfig, ModelSpec, ModelsConfig, ToolsConfig
+from agent_core.engine import EngineComponents, RunRequest, RunResult, RunStatus
+
+
+class DummyEngine:
+    def __init__(self) -> None:
+        self.calls: list[tuple[RunRequest, EngineComponents]] = []
+
+    async def execute(self, request: RunRequest, components: EngineComponents) -> RunResult:
+        self.calls.append((request, components))
+        return RunResult(status=RunStatus.SUCCESS, output_text="ok")
+
+
+def _basic_config() -> AgentCoreConfig:
+    return AgentCoreConfig(
+        engine=EngineConfig(key="local"),
+        models=ModelsConfig(
+            roles={"actor": ModelSpec(provider="mock", model="deterministic")}
+        ),
+        tools=ToolsConfig(allowlist=[]),
+    )
+
+
+def test_from_config_builds_instance() -> None:
+    core = AgentCore.from_config(_basic_config())
+    assert isinstance(core, AgentCore)
+    assert core.config.engine.key == "local"
+
+
+def test_from_file_loads_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "agent_core.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "engine": {"key": "local", "config": {}},
+                "models": {
+                    "roles": {
+                        "actor": {"provider": "mock", "model": "deterministic"}
+                    }
+                },
+                "tools": {"allowlist": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+    core = AgentCore.from_file(str(config_path))
+    assert core.config.engine.key == "local"
+    assert "actor" in core.config.models.roles
+
+
+def test_from_env_loads_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_CORE_APP__NAME", "agent-core-test")
+    core = AgentCore.from_env()
+    assert core.config.app.name == "agent-core-test"
+
+
+@pytest.mark.asyncio
+async def test_run_uses_engine_and_components() -> None:
+    engine = DummyEngine()
+    sentinel = object()
+    core = AgentCore(
+        _basic_config(),
+        engine=engine,
+        models={"actor": sentinel},
+    )
+
+    request = RunRequest(input="hi")
+    result = await core.run(request)
+
+    assert result.status == RunStatus.SUCCESS
+    assert engine.calls
+    called_request, called_components = engine.calls[0]
+    assert called_request is request
+    assert called_components.models == {"actor": sentinel}
+
+
+@pytest.mark.asyncio
+async def test_run_with_artifacts_returns_bundle() -> None:
+    engine = DummyEngine()
+    sentinel = object()
+    core = AgentCore(
+        _basic_config(),
+        engine=engine,
+        models={"actor": sentinel},
+    )
+
+    request = RunRequest(input="hi")
+    result, artifact = await core.run_with_artifacts(request)
+
+    assert result.status == RunStatus.SUCCESS
+    assert isinstance(artifact, RunArtifact)
+    assert artifact.run_id == request.run_id
+    assert artifact.result == result
+
+
+def test_run_sync_executes() -> None:
+    engine = DummyEngine()
+    sentinel = object()
+    core = AgentCore(
+        _basic_config(),
+        engine=engine,
+        models={"actor": sentinel},
+    )
+
+    result = core.run_sync(RunRequest(input="sync"))
+    assert result.status == RunStatus.SUCCESS
+
+
+def test_run_sync_rejects_running_loop() -> None:
+    engine = DummyEngine()
+    sentinel = object()
+    core = AgentCore(
+        _basic_config(),
+        engine=engine,
+        models={"actor": sentinel},
+    )
+
+    async def _runner() -> None:
+        with pytest.raises(RuntimeError):
+            core.run_sync(RunRequest(input="fail"))
+
+    asyncio.run(_runner())


### PR DESCRIPTION
## Description

Implement the AgentCore public API (constructors + run helpers) as the primary user entry point. Adds documentation, tests, and a sample config for e2e coverage.

Closes #97

## Changes

- Add AgentCore API with from_file/from_env/from_config and run/run_sync/run_with_artifacts.
- Add unit + integration tests and API documentation.
- Update README quick start to use AgentCore.

## Evidence Mapping

| Criterion | Test | Location | Status |
|-----------|------|----------|--------|
| AC1-3 (constructors) | `pytest tests/unit/agent_core/test_agent_core.py -q` | `tests/unit/agent_core/test_agent_core.py` | ? |
| AC4-6 (run/run_sync/run_with_artifacts) | `pytest tests/unit/agent_core/test_agent_core.py -q` | `tests/unit/agent_core/test_agent_core.py` | ? |
| AC7-8 (composition wiring) | `pytest tests/unit/agent_core/test_agent_core.py -q` | `tests/unit/agent_core/test_agent_core.py` | ? |
| AC11 (from_file -> run e2e) | `pytest tests/integration/test_agent_core_e2e.py -q` | `tests/integration/test_agent_core_e2e.py` | ? |
| AC12 (coverage >= 85%) | `pytest tests/unit/agent_core/test_agent_core.py --cov=agent_core.api --cov-report=term-missing -q` | `src/agent_core/api.py` | ? |
| AC13-14 (docs + quick start) | Doc review | `docs/agent_core_api.md`, `README.md` | ? |

## Checklist

### Code Quality
- [x] All acceptance criteria met with evidence above
- [x] Tests added and passing
- [x] No regressions (existing tests pass)
- [x] Code follows project conventions
- [x] No debug statements or commented code

### Documentation
- [x] README updated (if applicable)
- [x] API docs updated (if applicable)
- [x] Code comments for complex logic

### Process
- [x] PR linked to story (`Closes #`)
- [x] Branch follows naming convention
- [x] Branch up to date with base (release/0.1.0)
- [x] Self-reviewed the diff

## Screenshots (if UI change)

| Before | After |
|--------|-------|
| | |

## Notes for Reviewers

- Full agent_core test run: `pytest tests/unit/agent_core tests/integration -q` (120 passed).

---

**For Reviewer:** Validate evidence mapping before approving.
**For CODEOWNER:** Run pre-merge checklist before merging.
